### PR TITLE
Fixed typo in 'asset-manager'

### DIFF
--- a/pages/03.themes/07.asset-manager/docs.md
+++ b/pages/03.themes/07.asset-manager/docs.md
@@ -61,7 +61,7 @@ JavaScript assets are very similar:
     {% do assets.addJs('theme://js/modernizr.custom.71422.js',100) %}
     {% do assets.addJs('theme://js/antimatter.js') %}
     {% do assets.addJs('theme://js/slidebars.min.js') %}
-    {% do assets.addInineJs('alert(\'This is inline!\')') %}
+    {% do assets.addInlineJs('alert(\'This is inline!\')') %}
 {% endblock %}
 {{ assets.js() }}
 ```


### PR DESCRIPTION
From 'addInineJs' to 'addInlineJs' in the "Assets in Themes" section.
