### PR TITLE
Typo in meta file example

### DIFF
--- a/pages/02.content/07.media/docs.md
+++ b/pages/02.content/07.media/docs.md
@@ -772,7 +772,7 @@ You can add just about any setting or piece of metadata you would like using thi
 The contents of this file should be in YAML syntax, an example could be:
 
 ```ruby
-images:
+image:
 	filters:
 		default:
 			- [cropResize, 300, 300]


### PR DESCRIPTION
Tried example shown and was not working, once changed to `image:` example did work.
