### PR TITLE
Fix hyperlink

### DIFF
--- a/pages/06.advanced/14.contact-form/docs.md
+++ b/pages/06.advanced/14.contact-form/docs.md
@@ -97,8 +97,7 @@ The `formdata` page template is provided in Antimatter and other themes. If your
 
 That's it!
 
-!!! Modular pages are a bit different. In this case, also see [using forms in modular pages
-](http://learn.getgrav.org/advanced/forms#using-forms-in-modular-pages)
+!!! Modular pages are a bit different. In this case, also see [using forms in modular pages](http://learn.getgrav.org/advanced/forms#using-forms-in-modular-pages)
 
 When users submit the form, the plugin will send an email to you (as set in the `from` setting of the Grav Email Plugin), and will save the entered data in the data/ folder.
 


### PR DESCRIPTION
Remove newline that was breaking hyperlink on Grav-rendered page

Screenshot of broken hyperlink on Grav-rendered page:
![grav-newline-before](https://cloud.githubusercontent.com/assets/7143133/12004446/798cb22e-ab0e-11e5-9676-3f3850fda54f.png)
