### PR TITLE
Updated contents of mytheme.php text

### DIFF
--- a/pages/03.themes/08.customization/docs.md
+++ b/pages/03.themes/08.customization/docs.md
@@ -97,12 +97,14 @@ To achieve this you need to follow these steps:
 
 5. Create a new theme Class file that can be used to add advanced event-driven functionality. Create a `user/themes/mytheme/mytheme.php` file:
    ```
-   namespace Grav\Theme;
+   <?php
+     namespace Grav\Theme;
 
-   class Mytheme extends Antimatter
-   {
-      // Some new methods, properties etc.
-   }
+     class Mytheme extends Antimatter
+     {
+         // Some new methods, properties etc.
+     }
+   ?>  
    ```
 
 You have now created a new theme called **mytheme** and set up the streams so that it will first look in the **mytheme** theme first, then try **antimatter**.  So in essence, Antimatter is the base-theme for this new theme.


### PR DESCRIPTION
Going through these updated docs and trying out a new theme with inheritance, I noticed that ' <?php' and ' ?>' were missing from the example mytheme.php file so I have added them.
