### PR TITLE
Remove newline

### DIFF
--- a/pages/02.content/01.content-pages/docs.md
+++ b/pages/02.content/01.content-pages/docs.md
@@ -44,8 +44,7 @@ A modular page is a special type of listing page because it actually builds a **
 
 Each of these page types follow the same basic structure, so before we can get into the nitty-gritty of each type, we must explain how pages in Grav are constructed.
 
-!! A modular page, because it is intended to be part of another page, is inherently not a page you can reach
-directly via a URL.  Because of this, all modular pages are by default set as **non-routable**.
+!! A modular page, because it is intended to be part of another page, is inherently not a page you can reach directly via a URL.  Because of this, all modular pages are by default set as **non-routable**.
 
 ## Folders
 


### PR DESCRIPTION
Remove a newline that, when present, was (as shown in the attached screenshot) causing the text that followed it to appear _outside_ of the "Info" box that contained the earlier portion of the same sentence.

![grav-newline-before](https://cloud.githubusercontent.com/assets/7143133/12062466/fdd15ee4-af51-11e5-90ac-03a3a876665e.png)
