### PR TITLE
Delete irrelevant "Notice"

### DIFF
--- a/pages/03.themes/01.theme-basics/docs.md
+++ b/pages/03.themes/01.theme-basics/docs.md
@@ -151,4 +151,3 @@ Let us use the default **antimatter** theme as an example, below you can see the
 
 In this example, the actual `css`, `css-compiled`, `fonts`, `images`, `js`, `scss`, and `templates` files have been ignored to make it more readable.  The important thing to note is the overall structure of the theme.
 
->>>The `index.html` file is just a blank file.


### PR DESCRIPTION
The deleted "Notice" refers to a file named `index.html`; but there is no `index.html` file mentioned anywhere else on the page, including in the image immediately preceding the deleted text.
