### PR TITLE
Change URL for 'Grav-CLI-Plugin'

### DIFF
--- a/pages/04.plugins/02.plugin-tutorial/docs.md
+++ b/pages/04.plugins/02.plugin-tutorial/docs.md
@@ -236,4 +236,4 @@ public function onPageContentProcessed(Event $event)
 
 ### Implementing CLI to your Plugin
 
-Plugins have also the capability of integrating with the `bin/plugin` command line to execute tasks. You can follow the [advanced tutorial](../advanced/grav-cli-plugin) if you desire to implement such functionality.
+Plugins have also the capability of integrating with the `bin/plugin` command line to execute tasks. You can follow the [advanced tutorial](/advanced/grav-cli-plugin) if you desire to implement such functionality.


### PR DESCRIPTION
The URL pointing to the Grav-CLI-Plugin tutorial is incorrect, and should be changed to:

`/advanced/grav-cli-plugin`
