### PR TITLE
Update documentation.

### DIFF
--- a/pages/09.troubleshooting/03.internal-server-error/docs.md
+++ b/pages/09.troubleshooting/03.internal-server-error/docs.md
@@ -76,6 +76,10 @@ RewriteBase /
 
 (Credit: [http://ahcox.com/webdev/1and1-internal-server-error-grav/](http://ahcox.com/webdev/1and1-internal-server-error-grav/))
 
+### File Permission Problems
+
+Some shared hosting servers will generate an HTTP 500 error if your file permissions are less restrictive that the server's enforced file permissions. For example, HostGator shared hosting servers enforce a policy that generates a HTTP 500 error if permissions are greater than 644 for files or 755 for directories.
+
 ### Admin Panel Navigation
 
 When navigating through Grav's admin panel, **Internal Server Error** message appears in the top left.  This is due to incorrect permissions on your /cache folder.

--- a/pages/09.troubleshooting/05.permissions/docs.md
+++ b/pages/09.troubleshooting/05.permissions/docs.md
@@ -22,10 +22,10 @@ A simple **permissions-fixing** shell script can be used to do this:
     #!/bin/sh
     chown joeblow:staff .
     chown -R joeblow:staff *
-    find . -type f | xargs chmod 664
-    find ./bin -type f | xargs chmod 775
-    find . -type d | xargs chmod 775
-    find . -type d | xargs chmod +s
+    find . -type f -exec chmod 664 {} \;
+    find ./bin -type f -exec chmod 775 {} \;
+    find . -type d -exec chmod 775 {} \;
+    find . -type d -exec chmod +s {} \;
     umask 0002
 
 You can use this file and edit as needed for the appropriate user and group that works for your setup.  What this script basically does, is:


### PR DESCRIPTION
1. Add a note that some shared hosts generate HTTP 500 on file permissions they consider insecure.
2. Remove pipe to xargs in sample script to fix file permissions.
