### PR TITLE
Change description for page.summary(size)

### DIFF
--- a/pages/03.themes/06.theme-vars/docs.md
+++ b/pages/03.themes/06.theme-vars/docs.md
@@ -58,7 +58,7 @@ The **page object** is probably _the_ most important object you will work with a
 
 ##### summary([size])
 
-This returns a truncated or shortened version of your content.  You can provide an optional `size` parameter to specify the number of words.  Alternatively, if no size is provided, the value can be obtained via the site-wide variable `summary.size` from your `site.yaml` configuration.
+This returns a truncated or shortened version of your content.  You can provide an optional `size` parameter to specify the maximum length of the summary, in characters.  Alternatively, if no size is provided, the value can be obtained via the site-wide variable `summary.size` from your `site.yaml` configuration.
 
 ```
 {{ page.summary }}


### PR DESCRIPTION
This fixes issue #236, regarding the `size` parameter for content summaries.

The parameter is correctly documented in `pages/01.basics/05.grav-configuration/docs.md` when referring to the `site.yaml` file, but `pages/03.themes/06.theme-vars/docs.md` is a little ambiguous and says it limits by the number of **words**.
