### PR TITLE
correct name of content.order.dir variable

### DIFF
--- a/pages/02.content/03.collections/docs.md
+++ b/pages/02.content/03.collections/docs.md
@@ -226,7 +226,7 @@ Ordering of sub-pages follows the same rules as ordering of folders, the availab
 | **manual**   | The order based on the `order_manual` variable                                                                                                     |
 | **random**   | The order is randomized                                                                                                                            |
 
-The `content.items.dir` variable controls which direction the ordering should be in. Valid values are either `desc` or `asc`.
+The `content.order.dir` variable controls which direction the ordering should be in. Valid values are either `desc` or `asc`.
 
 In this configuration, you can see that `content.order.custom` is defining a **custom manual ordering** to ensure the page is constructed with the **showcase** first, **highlights** section second etc. Please note that if a page is not specified in the custom ordering list, then Grav falls back on the `content.order.by` for the unspecified pages.
 


### PR DESCRIPTION
just a minor correction thought you'd like to know about
