### PR TITLE
The Notices

### DIFF
--- a/pages/07.cli-console/02.grav-cli-plugin/docs.md
+++ b/pages/07.cli-console/02.grav-cli-plugin/docs.md
@@ -44,7 +44,7 @@ With **list** you can access all the available commands and view a quick descrip
 
 Here is an example with the **login** plugin when we run the command `bin/plugin login list`.
 
-! Not specifying any command after the plugin slug defaults automatically to `list`. This means that both `bin/plugin [slug] list` and `bin/plugin [slug]` are equivalent.
+!!! Not specifying any command after the plugin slug defaults automatically to `list`. This means that both `bin/plugin [slug] list` and `bin/plugin [slug]` are equivalent.
 
 ![](bin-plugin-login.png)
 
@@ -159,4 +159,4 @@ class HelloCommand extends ConsoleCommand
 
 ![](grav-plugin-hello.png)
 
-! Another good simple example can be found in the [Error Plugin (LogCommand.php)](https://github.com/getgrav/grav-plugin-error/blob/develop/cli/LogCommand.php), If you are looking for a more complex example, you should have a look at the [Login Plugin (NewUserCommand.php)](https://github.com/getgrav/grav-plugin-login/blob/develop/cli/NewUserCommand.php)
+!!! Another good simple example can be found in the [Error Plugin (LogCommand.php)](https://github.com/getgrav/grav-plugin-error/blob/develop/cli/LogCommand.php), If you are looking for a more complex example, you should have a look at the [Login Plugin (NewUserCommand.php)](https://github.com/getgrav/grav-plugin-login/blob/develop/cli/NewUserCommand.php)


### PR DESCRIPTION
I'm guessing 
'! text'
used to generate a MD Notice/Info box... 

'! Not specifying any command after the plugin slug defaults automatically to `list`. This means that both `bin/plugin [slug] list` and `bin/plugin [slug]` are equivalent.'

'! Another good simple example can be found in the [Error Plugin (LogCommand.php)](https://github.com/getgrav/grav-plugin-error/blob/develop/cli/LogCommand.php), If you are looking for a more complex example, you should have a look at the [Login Plugin (NewUserCommand.php)](https://github.com/getgrav/grav-plugin-login/blob/develop/cli/NewUserCommand.php)'
