### PR TITLE
Fix stray uppercase W in Twig

### DIFF
--- a/pages/03.themes/03.twig-primer/docs.md
+++ b/pages/03.themes/03.twig-primer/docs.md
@@ -141,5 +141,5 @@ Functions can generate content. They are typically followed by arguments, which 
 * [Official Twig Documentation](http://twig.sensiolabs.org/documentation)
 * [Twig for Template Designers](http://twig.sensiolabs.org/doc/templates.html)
 * [Twig for Developers](http://twig.sensiolabs.org/doc/api.html)
-* [6 Minute Video Introduction to TWig](http://www.dev-metal.com/6min-video-introduction-twig-php-templating-engine/)
+* [6 Minute Video Introduction to Twig](http://www.dev-metal.com/6min-video-introduction-twig-php-templating-engine/)
 * [Introduction to Twig](http://www.slideshare.net/markstory/introduction-to-twig)


### PR DESCRIPTION
Just happened to catch this small typo right now while reading the docs on making a Grav theme. :)
