### PR TITLE
Slight fix on Grav CLI and GPM redirect links 404

### DIFF
--- a/pages/09.webservers-hosting/02.vps/generic/default.md
+++ b/pages/09.webservers-hosting/02.vps/generic/default.md
@@ -162,7 +162,7 @@ $ mv grav html
 
 Now That's done you can confirm Grav is installed by poiting your browser to `http://{{ page.header.localname }}` and you should be greeted with the **Grav is Running!** page.
 
-Because you have followed these instructions diligently, you will also be able to use the [Grav CLI](../../advanced/grav-cli) and [Grav GPM](../../advanced/grav-gpm) commands such as:
+Because you have followed these instructions diligently, you will also be able to use the [Grav CLI](../../../advanced/grav-cli) and [Grav GPM](../../../advanced/grav-gpm) commands such as:
 
 ```
 $ cd ~/www/html


### PR DESCRIPTION
They currently 404 because the folder level is within Webservers/Hosting instead of the folder level above. Adding one more ../ will correctly redirect to cli-console/*, hence the proposed pull request.
