### PR TITLE
Fix typo on line 19

### DIFF
--- a/.dependencies
+++ b/.dependencies
@@ -16,7 +16,7 @@ git:
         path: user/plugins/github
         branch: develop
     hightlight:
-        url: https://github.com/getgrav/grav-plugin-hightlight
+        url: https://github.com/getgrav/grav-plugin-highlight
         path: user/plugins/hightlight
         branch: develop
     markdown-notices:


### PR DESCRIPTION
Replace : https://github.com/getgrav/grav-plugin-hightlight
With :       https://github.com/getgrav/grav-plugin-highlight
