### PR TITLE
Syntax highlighting requires the Highlight plugin

### DIFF
--- a/pages/02.content/04.markdown/docs.md
+++ b/pages/02.content/04.markdown/docs.md
@@ -520,6 +520,8 @@ grunt.initConfig({
 };
 ```
 
+!!! For syntax highlighting to work, the [Highlight plugin](https://github.com/getgrav/grav-plugin-highlight) needs to be installed and enabled. It in turn utilizes a jquery plugin, so jquery needs to be loaded in your theme too.
+
 <br>
 <br>
 <br>


### PR DESCRIPTION
I was wondering why the syntax highlighting didn't work and had to dig around a bit to figure out I need the Highlight plugin and load jquery in my basic page layout.
