### PR TITLE
Duplicated Text in Form Action Reference

### DIFF
--- a/pages/06.forms/02.forms/02.reference-form-actions/docs.md
+++ b/pages/06.forms/02.forms/02.reference-form-actions/docs.md
@@ -152,7 +152,6 @@ process:
 ### Reset the form after submit
 
 By default the form is not cleared after the submit. So if you don't have a `display` action and the user is sent back to the form page, it's still filled with the data entered. If you want to avoid this, add a `reset` action:
-Display the user's IP address on the output. Put it above email / save processes in the 'form.md' to ensure it is used by the output processe(s)
 
 ````
 reset: true


### PR DESCRIPTION
Possibly duplicated sentences in the section [Reference: Form Actions](https://learn.getgrav.org/forms/forms/reference-form-actions#reset-the-form-after-submit) from the previous section "User IP Address", which don't make any sense for resetting a form