### PR TITLE
Rename Forms to Form to match the plugin name and add a small note about installing the plugin

### DIFF
--- a/pages/06.forms/02.forms/docs.md
+++ b/pages/06.forms/02.forms/docs.md
@@ -4,11 +4,11 @@ taxonomy:
     category: docs
 ---
 
-The **Forms** plugin gives you the ability to create virtually any type of frontend form. It is essentially a form construction kit, available for you to use in your own pages.
+The **Form** plugin gives you the ability to create virtually any type of frontend form. It is essentially a form construction kit, available for you to use in your own pages. Before going any further, don't forget to install the [**Form** plugin](https://github.com/getgrav/grav-plugin-form) with `bin/gpm install form` if it's not installed yet.
 
-To get an understanding of how the **Forms** plugin works, let's start by going over how to create a simple form.
+To get an understanding of how the **Form** plugin works, let's start by going over how to create a simple form.
 
-!!!! With **Forms 2.0** release, it is now required to pass the **name of the form** as a hidden field.  If you are using the form-plugin-provided `forms.html.twig`, this is handled automatically, however, if you have overridden the default `forms.html.twig` in your theme or plugin, you should manually add `{% include "forms/fields/formname/formname.html.twig" %}` in your form-rendering Twig file.
+!!!! With **Form 2.0** release, it is now required to pass the **name of the form** as a hidden field.  If you are using the form-plugin-provided `forms.html.twig`, this is handled automatically, however, if you have overridden the default `forms.html.twig` in your theme or plugin, you should manually add `{% include "forms/fields/formname/formname.html.twig" %}` in your form-rendering Twig file.
 
 ## Create a simple single form
 
@@ -71,7 +71,7 @@ Regular **markdown** content goes here...
 
 !!! This is the content of the `form.md` file, when viewed via file-system. To do this via Admin Plugin, open the page in **Expert Mode**, copy the part between the triple dashes `---`, and paste it the Frontmatter field.
 
-This is enough to show a form in the page, below the page's content. It is a simple form with a name, email field, two buttons: one to submit the form and one to reset the fields. For more information on the available fields that are provided by the Forms plugin, [checkout the next section](fields-available).
+This is enough to show a form in the page, below the page's content. It is a simple form with a name, email field, two buttons: one to submit the form and one to reset the fields. For more information on the available fields that are provided by the Form plugin, [checkout the next section](fields-available).
 
 What happens when you press the `Submit` button?  It executes the `process` actions in series. To find out about other actions, [check out the available options](reference-form-actions) or [create your own](reference-form-actions#add-your-own-custom-processing-to-a-form).
 
@@ -85,7 +85,7 @@ What happens when you press the `Submit` button?  It executes the `process` acti
 
 ## Multiple Forms
 
-With the release of **Forms Plugin v2.0**, you are now able to define multiple forms in a single page.  The syntax is similar but each form is differentiated by the name of the form, in this case `contact-form` and `newsletter-form`:
+With the release of **Form Plugin v2.0**, you are now able to define multiple forms in a single page.  The syntax is similar but each form is differentiated by the name of the form, in this case `contact-form` and `newsletter-form`:
 
 ```
 forms:
@@ -127,7 +127,7 @@ The easiest way to include a form is to simply include a Twig file in the templa
 {% include "forms/form.html.twig" %}
 ```
 
-This will use the Twig template provided by the Forms plugin itself.  In turn, it will render the form as you have defined in the page, and handle displaying a success message, or errors, when the form is submitted.
+This will use the Twig template provided by the Form plugin itself.  In turn, it will render the form as you have defined in the page, and handle displaying a success message, or errors, when the form is submitted.
 
 There is however a more powerful method of displaying forms that can take advantage of the new multi-forms support.  With this method you actually pass a `form:` parameter to the Twig template specifying the form you wish to display:
 
@@ -179,9 +179,9 @@ cache_enable: false
 
 ## Modular Forms
 
-With previous versions of the Forms plugin, to get a form to display in a modular sub-page of your overall **modular** page, you had to define the form in the **top-level modular page**.  This way the form would be processed and available to display in the modular sub-page.
+With previous versions of the Form plugin, to get a form to display in a modular sub-page of your overall **modular** page, you had to define the form in the **top-level modular page**.  This way the form would be processed and available to display in the modular sub-page.
 
-In **Forms v2.0**, you can now define the form directly in the modular sub-page just like any other form.  However, if not found, the forms plugin will look in the 'current page', i.e. the top-level modular page for a form, so it's fully backwards compatible with the 1.0 way of doing things.
+In **Form v2.0**, you can now define the form directly in the modular sub-page just like any other form.  However, if not found, the form plugin will look in the 'current page', i.e. the top-level modular page for a form, so it's fully backwards compatible with the 1.0 way of doing things.
 
 You can also configure your Modular sub-page's Twig template to use a form from another page, like the examples above.
 


### PR DESCRIPTION
Hi there,

So yeah, I might be picky, but the doc doesn't have the right plugin name, as it's called **Form** and not **Forms**. But that's just a detail.

I actually spend 15 minutes searching why my `{% include "forms/form.html.twig" %}` wasn't working. It's because I didn't have the plugin installed *face palm*. I thought mentioning it in the doc might save some time to others (maybe not).