### PR TITLE
Update nginx configuration documentations

### DIFF
--- a/pages/09.webservers-hosting/00.local/01.nginx/docs.md
+++ b/pages/09.webservers-hosting/00.local/01.nginx/docs.md
@@ -125,10 +125,10 @@ http {
 Grav gets shipped with a configuration file for your site in the `webserver-configs` directory of your Grav installation. You can copy that file into your nginx config directory:
 
 ```bash
-cp /var/www/grav/webserver-configs/nginx /etc/nginx/sites-available/grav-site
+cp /var/www/grav/webserver-configs/nginx.conf /etc/nginx/sites-available/grav-site
 ```
 
-Open that file with an editor and replace "domain.tld" with your domain/IP (or "localhost" if you want to just run it locally), then create a symbolic link of your site-config in `sites-enabled`:
+Open that file with an editor and replace "domain.tld" with your domain/IP (or "localhost" if you want to just run it locally), replace the "root" line with "root /var/www/grav/;" and then create a symbolic link of your site-config in `sites-enabled`:
 
 ```bash
 ln -s /etc/nginx/sites-available/grav-site /etc/nginx-sites-enabled/grav-site


### PR DESCRIPTION
Update tutorial so that it works with v1.1.12:
* add extension to default nginx config file location
* add missing step to update root location.