### PR TITLE
Fixing 'Wrapping markdown into html' example

### DIFF
--- a/pages/10.cookbook/01.general-recipes/docs.md
+++ b/pages/10.cookbook/01.general-recipes/docs.md
@@ -267,10 +267,10 @@ pages:
 in your wrapper tag make sure to add the parameter `markdown="1"` to activate processing of markdown content:
 
 ```
-<div class="myWrapper" markdown="1" >
-    # my markdown content
+<div class="myWrapper" markdown="1">
+# my markdown content
 
-    this content is wrapped into a div with class "myWrapper"
+this content is wrapped into a div with class "myWrapper"
 </div>
 ```
 


### PR DESCRIPTION
As indenting the nested markdown as it was previously makes it parse as a &lt;pre&gt;&lt;code&gt; block which isn't what was intended.