### PR TITLE
Add CHANGELOG format note

### DIFF
--- a/pages/08.advanced/09.grav-development/docs.md
+++ b/pages/08.advanced/09.grav-development/docs.md
@@ -115,6 +115,8 @@ The GetGrav.org site uses a custom ChangeLog format that is written in standard 
 
 Each section `#new, #improved, #bugfix` are optional, just include the sections you need.
 
+! Dates can use either the **American** `m/d/y` [date format](/content/headers#date), or the **European** `d-m-y` format. Also make sure there is an empty newline between the headers (version and date) and lists (new, improved, bugfix).
+
 ## GitHub Setup
 
 As is the way of things these days, GitHub is going to be your best friend when it comes to developing for Grav.  We have created some tools to make this as easy as possible, but there are some development patterns that you should follow to make the process simpler.


### PR DESCRIPTION
To avoid a bit of confusion in the formatting of Changelogs, add a brief note about date formats and newlines.  [Reference](https://github.com/getgrav/grav/issues/1284).