### PR TITLE
Clarified the second example under Field Ordering

### DIFF
--- a/pages/06.forms/01.blueprints/07.advanced-features/docs.md
+++ b/pages/06.forms/01.blueprints/07.advanced-features/docs.md
@@ -234,6 +234,8 @@ form:
 
 In the example above, we used the name of another field to set the ordering. In this example, we have set it up so that the `author` field appears after the `title` field in the form.
 
+!! When ordering fields in a page blueprint, you still need to reference the field names prefiexed with `page.`, eg: `page.title` for the ordering to work.
+
 # Creating new form field type
 
 If you create a special form field type, which needs a special handling in blueprints, there is a plugin function that you can use.

--- a/pages/06.forms/01.blueprints/07.advanced-features/docs.md
+++ b/pages/06.forms/01.blueprints/07.advanced-features/docs.md
@@ -234,7 +234,7 @@ form:
 
 In the example above, we used the name of another field to set the ordering. In this example, we have set it up so that the `author` field appears after the `title` field in the form.
 
-!! When ordering fields in a page blueprint, you still need to reference the field names prefiexed with `page.`, eg: `page.title` for the ordering to work.
+!! When ordering fields in a page blueprint, you still need to reference the field names prefiexed with `header.`, eg: `header.title` for the ordering to work.
 
 # Creating new form field type
 


### PR DESCRIPTION
Some new users might not notice that the example doesn't refer to a page blueprint (it defines a new field called `author`, not `header.author`). So they might try (as I did) to order a field in a page blueprint by doing `order@: title` instead of `order@: header.title`, which doesn't work.
I added a notice that helps draw attention to this.

Changes proposed in this pull request:
 - add a notice under the second example of ordering pages, that clarifies that the example doesn't refer to a page blueprint and shows how to correctly order fields in a page blueprint.

How to test this code:
 - read the docs page at [https://learn.getgrav.org/forms/blueprints/advanced-features#changing-field-ordering](https://learn.getgrav.org/forms/blueprints/advanced-features#changing-field-ordering)

Has been tested on (remove any that don't apply):
 - Grav 1.10
 - Ubuntu 14 and above
