### PR TITLE
Quick update to last PR just accepted

### DIFF
--- a/pages/02.content/03.collections/docs.md
+++ b/pages/02.content/03.collections/docs.md
@@ -8,7 +8,7 @@ Collections have grown considerably since the early betas of Grav. We started of
 
 ## Basics of Grav Collections
 
-In Grav, the most common type of collection is a list of pages that can be defined either in the page's frontmatter or in the twig itself. The most common is to define a collection in the frontmatter. With a collection defined, it is available in the Twig of the page to do with as you wish. By using page collection methods or looping through each page object and using the page methods or properties you can do powerful things. Common examples of this include displaying a list of blog posts, or displaying modular sub-pages to render a complex page design.
+In Grav, the most common type of collection is a list of pages that can be defined either in the page's frontmatter or in the twig itself. The most common is to define a collection in the frontmatter. With a collection defined, it is available in the Twig of the page to do with as you wish. By using page collection methods or looping through each [page object](https://learn.getgrav.org/themes/theme-vars#page-object) and using the page methods or properties you can do powerful things. Common examples of this include displaying a list of blog posts, or displaying modular sub-pages to render a complex page design.
 
 ## Collection Object
 
@@ -47,7 +47,7 @@ When this collection is defined in the header, Grav creates a collection **page.
 {% endfor %}
 ```
 
-This simply loops over the pages in the collection displaying the title and summary.
+This simply loops over the [pages](https://learn.getgrav.org/themes/theme-vars#page-object) in the collection displaying the title and summary.
 
 ## Collection Headers
 


### PR DESCRIPTION
I forgot to add before submitting that PR, but really think a link to the page object details in the theme variable section is much needed here. I remember that was hard to find at first.

Changes proposed in this pull request:
 - adds a link to the page object details

Has been tested on (remove any that don't apply):
 - Grav 1.10
 - Ubuntu 14 and above
