### PR TITLE
Clarified how modular pages are generated

### DIFF
--- a/pages/02.content/09.modular/docs.md
+++ b/pages/02.content/09.modular/docs.md
@@ -22,7 +22,15 @@ In the case of our **One-Page Skeleton**, we have created the folder structure p
 
 Each subfolder contains a markdown file which acts as a unique page.
 
-The data within these modular folders (including markdown files, images, etc.) is then pulled and displayed on the modular page. Here is an example of a modular page, highlighting the different modular folders which are used.
+The data within these modular folders (including markdown files, images, etc.) is then pulled and displayed on the modular page. This is accomplished by creating a primary page, defining a [page collection](/content/collections) in the primary page's YAML frontmatter, then iterating over this collection in a Twig template to generate the combined HTML page. A theme should already have a `modular.html.twig` template that will do this and is used when you create a modular page type. Here's a typical example from a `modular.html.twig`:
+
+```twig
+    {% for module in page.collection() %}
+        {{ module.content }}
+    {% endfor %}
+```
+
+Here is an example of the resulting modular page, highlighting the different modular folders which are used.
 
 {{ media['modular-explainer-1.jpg'].html('Listing Page','border') }}
 


### PR DESCRIPTION
Fixes #274 

Changes proposed in this pull request:
 - mention page collection being created on primary page and the Twig's role to iterate and generate

Has been tested on (remove any that don't apply):
 - Grav 1.10
 - Ubuntu 14 and above
