### PR TITLE
Changed code to grav 'locator'

### DIFF
--- a/pages/06.forms/01.blueprints/04.example-page-blueprint/docs.md
+++ b/pages/06.forms/01.blueprints/04.example-page-blueprint/docs.md
@@ -165,7 +165,7 @@ public static function getSubscribedEvents()
 public function onGetPageTemplates($event)
 {
   $types = $event->types;
-  $locator = Grav::instance()['locator'];
+  $locator = $this->grav['locator'];
   $types->scanBlueprints($locator->findResource('plugin://' . $this->name . '/blueprints'));
   $types->scanTemplates($locator->findResource('plugin://' . $this->name . '/templates'));
 }


### PR DESCRIPTION
Following the example to add a custom page blueprint via a plugin I got a PHP error on the original grav 'locator' line. I found another syntax for this function on the Grav repository, and when I replaced the code it worked.

I am not a PHP developer, so please carefully review this change if it is in fact the correct suggested method.
Thanks very much,
Paul

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Grav 1.10
 - Ubuntu 14 and above
