### PR TITLE
Minor french translation correction

### DIFF
--- a/pages/10.cookbook/02.twig-recipes/docs.md
+++ b/pages/10.cookbook/02.twig-recipes/docs.md
@@ -170,7 +170,7 @@ FRUITS: [Banana, Cherry, Lemon, Lime, Strawberry, Raspberry]
 And in `fr.yaml`:
 
 ```
-FRUITS: [Banana, Cerise, Citron, Citron Vert, Fraise, Framboise]
+FRUITS: [Banane, Cerise, Citron, Citron Vert, Fraise, Framboise]
 ```
 
 Then you have your Twig:


### PR DESCRIPTION
In French, "banana" is translated by "banane".