### PR TITLE
Skeleton-packages tip

### DIFF
--- a/pages/01.basics/03.installation/docs.md
+++ b/pages/01.basics/03.installation/docs.md
@@ -29,6 +29,8 @@ The easiest way to install Grav is to download the ZIP package and extract it:
 1. Download the latest-and-greatest **[Grav](https://getgrav.org/download/core/grav/latest)** or **[Grav + Admin](https://getgrav.org/download/core/grav-admin/latest)** package.
 2. Extract the ZIP file in the [webroot](https://www.wordnik.com/words/webroot) of your web server, e.g. `~/webroot/grav`
 
+!!! There are [Skeleton](https://getgrav.org/downloads/skeletons)-packages available, which include the core Grav system, sample pages, plugins, and configuration. They are a great way to get started; all you have to do is [download the Skeleton](https://getgrav.org/downloads/skeletons)-package you prefer, and follow the steps above.
+
 !!!! If you downloaded the ZIP file and then plan to move it to your webroot, please move the **ENTIRE FOLDER** because it contains several hidden files (such as .htaccess) that will not be selected by default. The omission of these hidden files can cause problems when running Grav.
 
 


### PR DESCRIPTION
An [issue](https://getgrav.org/forum#!/general:if-i-wanted-to-use-a-theme) highlighted on the forum some 15 minutes ago: The docs don't actually explain how to install a Skeleton. They are only referred to as examples, or explained as a part of [Advanced/Development](https://learn.getgrav.org/advanced/grav-development#grav-skeletons).

This PR simply adds a note in Basics/Installation, linking to the Skeletons page and paraphrasing what's written there. The broader concept of a "full-featured base install" - as actually specified in the default content of a fresh installation of Core (+ Admin) - should perhaps be added somewhere in the docs, to avoid confusion for people trying to install for the first time.