### PR TITLE
Fix Heroku deployment guide adding post install command 

### DIFF
--- a/pages/09.webservers-hosting/03.paas/02.heroku/docs.md
+++ b/pages/09.webservers-hosting/03.paas/02.heroku/docs.md
@@ -70,23 +70,21 @@ Now commit to the repository with
 
 `git add . ; git commit -am 'Added Grav'`
 
-Then run
-
-`git push heroku master`
-
-and install plugin and theme dependencies with
-
-`heroku run bin/grav install`
-
-and the site should be good to go!
-
-As an alternative to the last step, edit `composer.json` and add post deploy commands to the `scripts` section as in
+Then edit `composer.json` and add post deploy command to the `scripts` section as in
 
 ```
 "scripts": {
         "compile": [
-          "bin/grav clear-cache",
-          "bin/grav install",
-          "bin/gpm update"  
+          "bin/grav install"
         ],
 ```
+
+and commit that to the repository with 
+
+`git add . ; git commit -am 'Add post deploy bin/grav install'`
+
+Then run
+
+`git push heroku master`
+
+and the site should be good to go!

--- a/pages/09.webservers-hosting/03.paas/02.heroku/docs.md
+++ b/pages/09.webservers-hosting/03.paas/02.heroku/docs.md
@@ -74,4 +74,19 @@ Then run
 
 `git push heroku master`
 
+and install plugin and theme dependencies with
+
+`heroku run bin/grav install`
+
 and the site should be good to go!
+
+As an alternative to the last step, edit `composer.json` and add post deploy commands to the `scripts` section as in
+
+```
+"scripts": {
+        "compile": [
+          "bin/grav clear-cache",
+          "bin/grav install",
+          "bin/gpm update"  
+        ],
+```

--- a/pages/09.webservers-hosting/03.paas/02.heroku/docs.md
+++ b/pages/09.webservers-hosting/03.paas/02.heroku/docs.md
@@ -88,3 +88,14 @@ Then run
 `git push heroku master`
 
 and the site should be good to go!
+
+Due to the ephemeral nature of Heroku's filesystem, all needed plugins or themes must be added to `composer.json` just like above and kept there so they are installed every time the site is pushed to Heroku. For example, if you need the `admin` plugin and a theme, add them in composer like in
+
+```
+"scripts": {
+        "compile": [
+          "bin/grav install",
+          "bin/gpm install admin -y",
+          "bin/gpm install awesome-theme-name-here -y"
+        ],
+```


### PR DESCRIPTION
Since themes and plugins are ignored by git through .gitignore, **the steps in this doc will result in a  Grav website with no theme or plugin**. A post-deployment Heroku command is needed to install them, but just running `heroku bin/grav install` won't work. The only way I found to run post push commands is to add them to `composer.json`. 

Another alternative would be off course edit .gitignore and push themes and plugins directly.

Changes proposed in this pull request:
 - add all post deployment commands to `composer.json` scripts section

How to test this code:
 - follow the guide and try to access the site: the server will inform that the theme is missing
 - add `bin/grav install` to `scripts : compile` section as suggested, git push and reload the page: Grav is now working
 - now add `bin/gpm install admin -y` to `scripts : compile` section as suggested, git push and reload the page again: Grav admin interface will greet you

Has been tested on:
 - Grav 1.20 installed with `composer create-project getgrav/grav --no-dev`
 - Heroku-CLI 5.8.1

PS: Sorry for pulling a non-working patch. Newbie mistake, I have now followed the steps I'm suggesting and it's working.