### PR TITLE
Update docs.md

### DIFF
--- a/pages/10.cookbook/03.plugin-recipes/docs.md
+++ b/pages/10.cookbook/03.plugin-recipes/docs.md
@@ -89,7 +89,7 @@ class ExampleTwigExtension extends \Twig_Extension
 }
 ```
 
-`example.twig`:
+`example.yaml`:
 
 ```
 enabled: true


### PR DESCRIPTION
'example.twig' was a typo:  this should refer to 'example.yaml' (as user is asked to create).

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Grav 1.10
 - Ubuntu 14 and above
