### PR TITLE
Typo docs.md, filepicker example  (acccept -> accept)

### DIFF
--- a/pages/06.forms/01.blueprints/01.fields-available/docs.md
+++ b/pages/06.forms/01.blueprints/01.fields-available/docs.md
@@ -516,7 +516,7 @@ picked_image:
   folder: 'theme@:/images/pages'
   label: Select a file
   preview_images: true
-  acccept:
+  accept:
     - .png
     - .jpg
 ```


### PR DESCRIPTION
Fixed typo on https://learn.getgrav.org/forms/blueprints/fields-available
- filepicker example had a typo "acccept"