### PR TITLE
Fixed "images://".

### DIFF
--- a/pages/02.content/06.image-linking/docs.md
+++ b/pages/02.content/06.image-linking/docs.md
@@ -109,7 +109,7 @@ In an absolute link, the link opens with a `/`. Here is an example of an absolut
 New in Grav 1.2 is the ability to reference and link images via PHP streams.  There are several built-in PHP streams available which are useful including:
 
 * `user://` - user folder. e.g. `user/`
-* `images://` - images folder. e.g. `user/images/`
+* `image://` - images folder. e.g. `user/images/`
 * `theme://` - current theme.  e.g. `user/themes/antimatter/`
 
 These allow you to easily access images that are traditionally outside of the Pages hierarchy (`user/pages/`).


### PR DESCRIPTION
A quick fix for a typo.