### PR TITLE
Changing default redirect code from 301 to 302.

### DIFF
--- a/pages/01.basics/05.grav-configuration/docs.md
+++ b/pages/01.basics/05.grav-configuration/docs.md
@@ -114,7 +114,7 @@ pages:
   etag: false
   vary_accept_encoding: false
   redirect_default_route: false
-  redirect_default_code: 301
+  redirect_default_code: 302
   redirect_trailing_slash: true
   ignore_files: [.DS_Store]
   ignore_folders: [.git, .idea]
@@ -159,8 +159,8 @@ The **Pages** section of the `system/config/system.yaml` file is where you set a
 * **etag**: Set the etag header tag. Can be set to `true` or `false`.
 * **vary_accept_encoding**: Add `Vary: Accept-Encoding` header. Can be set to `true` or `false`.
 * **redirect_default_route**: Automatically redirect to a page's default route. Can be set to `true` or `false`.
-* **redirect_default_code**: Default code to use for redirects. For example: `301`.
-* **redirect_trailing_slash**: Handle automatically or 301 redirect a trailing / URL.
+* **redirect_default_code**: Default code to use for redirects. For example: `302`.
+* **redirect_trailing_slash**: Handle automatically or 302 redirect a trailing / URL.
 * **ignore_files**: Files to ignore in Pages. Example: `[.DS_Store] `.
 * **ignore_folders**: Folders to ignore in Pages. Example: `[.git, .idea]`
 * **ignore_hidden**: Ignore all Hidden files and folders. Can be set to `true` or `false`.

--- a/pages/02.content/10.routing/docs.md
+++ b/pages/02.content/10.routing/docs.md
@@ -100,7 +100,7 @@ There are three system-level configuration options that affect Redirects:
 ```
 pages:
   redirect_default_route: false
-  redirect_default_code: 301
+  redirect_default_code: 302
   redirect_trailing_slash: true
 ```
 

--- a/pages/02.content/11.multi-language/docs.md
+++ b/pages/02.content/11.multi-language/docs.md
@@ -428,14 +428,14 @@ Add following to your .htaccess file and adopt the language slugs and domain nam
 # http://www.workingwith.me.uk/articles/scripting/mod_rewrite
 
 # handle top level e.g. http://grav-site.com/de
-RewriteRule ^en/?$ "http://grav-site.com" [R=301,L]
-RewriteRule ^de/?$ "http://grav-site.de" [R=301,L]
+RewriteRule ^en/?$ "http://grav-site.com" [R=302,L]
+RewriteRule ^de/?$ "http://grav-site.de" [R=302,L]
 
 # handle sub pages, exclude admin path
 RewriteCond %{REQUEST_URI} !(admin) [NC]
-RewriteRule ^en/(.*)$ "http://grav-site.com/$1" [R=301,L]
+RewriteRule ^en/(.*)$ "http://grav-site.com/$1" [R=302,L]
 RewriteCond %{REQUEST_URI} !(admin) [NC]
-RewriteRule ^de/(.*)$ "http://grav-site.de/$1" [R=301,L]
+RewriteRule ^de/(.*)$ "http://grav-site.de/$1" [R=302,L]
 ```
 
 if you know how to simplify the rewrite rules, please edit this page through the Github link in the upper left corner

--- a/pages/09.webservers-hosting/00.local/01.nginx/docs.md
+++ b/pages/09.webservers-hosting/00.local/01.nginx/docs.md
@@ -203,7 +203,7 @@ server {
     listen 80;
     server_name example.com www.example.com;
 
-    return 301 https://example.com$request_uri;
+    return 302 https://example.com$request_uri;
 }
 
 # redirect www https to non-www https
@@ -215,7 +215,7 @@ server {
     # add ssl cert & options
     include ssl.conf;
 
-    return 301 https://example.com$request_uri;
+    return 302 https://example.com$request_uri;
 }
 
 # serve website


### PR DESCRIPTION
A permanent redirect can not be changed remotely once it has been sent.

Permanent redirects (301 / 308) are exactly what the their descriptive
name suggest. A 301 or 308 will be indefinitely cached client-side,
sometimes even when a user clears their cache.

They should be used to keep search engine page rankings by sending a
permanent redirect on a page by page basis, not for site to site or
protocols (http to https).

For http:// to https://, the HSTS-header is much more suited, as a
client will not return to http:// for the duration that was set in the
header.

For this reason, I believe that the documentation should use temporary
redirects in examples, and if users truly believe they need 301, they
can adapt this to their needs later.

Additionally, temporary redirects can be influenced remotely and are not
that expensive on the webserver nowadays with event-based handlers.