### PR TITLE
Update docs.md

### DIFF
--- a/pages/01.basics/03.installation/docs.md
+++ b/pages/01.basics/03.installation/docs.md
@@ -60,6 +60,7 @@ Another method is to clone Grav from the GitHub repository, and then run a simpl
 
 2. Install **vendor dependencies** via [composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx):
    ```
+   $ cd ~/webroot/grav
    $ composer install --no-dev -o
    ```
 


### PR DESCRIPTION
Added $ cd ~/webroot/grav in step 3 of Option 3: Install from GitHub.
(To make it clear for beginners that one needs to be in grav directory when running $ composer install --no-dev -o)
(To prevent error message "Composer could not find a composer.json file in /Applications/MAMP/htdocs
To initialize a project, please create a composer.json file as described in the https://getcomposer.org/ "Getting Started" section")