### PR TITLE
Access properties when plugin name contains dashes

### DIFF
--- a/pages/04.plugins/01.plugin-basics/docs.md
+++ b/pages/04.plugins/01.plugin-basics/docs.md
@@ -35,5 +35,5 @@ config.plugins.pluginname.pluginproperty
 
 If plugin name contains dashes you should refer to its properties using :
 ```
-config.plugins.['plugin-name'].pluginproperty
+config.plugins['plugin-name'].pluginproperty
 ```

--- a/pages/04.plugins/01.plugin-basics/docs.md
+++ b/pages/04.plugins/01.plugin-basics/docs.md
@@ -32,3 +32,8 @@ To access plugin configuration settings via Twig (i.e. within a Theme), the gene
 ```
 config.plugins.pluginname.pluginproperty
 ```
+
+If plugin name contains dashes you should refer to its properties using :
+```
+config.plugins.['plugin-name'].pluginproperty
+```


### PR DESCRIPTION
When plugin name contains dashes the general format to access its properties is not working.
There are quite a few plugins affected so I added an extra example using the twig ['plugin-name'] format.