### PR TITLE
Optimised image file size could grow after caching

### DIFF
--- a/pages/05.admin-panel/02.dashboard/01.configuration-system/docs.md
+++ b/pages/05.admin-panel/02.dashboard/01.configuration-system/docs.md
@@ -163,7 +163,9 @@ This section determines how Grav handles media content. Image quality, file uplo
 | Cache All Images           | Run all images through Grav's cache system even if they have no media manipulations.                      |
 | Image Debug Watermark      | Show an overlay over images indicating the pixel depth of the image when working with Retina for example. |
 | File Upload Limit          | Set maximum upload size in bytes (0 is unlimited).                                                        |
-| Enable Timestamps on Media | Appends a timestamp based on last modified date to each media item.                                       |
+| Enable Timestamps on Media | Appends a timestamp based on last modified date to each media item.                                       
+
+!! Caching images that have already been optimised (outside of Grav) could result in the output file being a much larger filesize than the original. This is due to a bug in the Gregwar image library and not directly related to Grav (see this ![open issue](https://github.com/Gregwar/Image/issues/115) for more information). The alternative is to set "Cache All Images" to No
 
 ### Session
 


### PR DESCRIPTION
Added an information tip about this bug in the Gregwar image library https://github.com/Gregwar/Image/issues/115 which could cause image file sizes to grow a lot after processing.