### PR TITLE
Fix Doctrine Cache link in Caching documentation 

### DIFF
--- a/pages/08.advanced/02.performance-and-caching/docs.md
+++ b/pages/08.advanced/02.performance-and-caching/docs.md
@@ -28,7 +28,7 @@ taxonomy:
 
 Caching is an integral feature of Grav that has been baked in from the start.  The caching mechanism that Grav employs is the primary reason Grav is as fast as it is.  That said, there are some factors to take into account.
 
-Grav uses the established and well-respected [Doctrine Cache](http://docs.doctrine-project.org/en/latest/reference/caching.html) library. This means that Grav supports any caching mechanism that Doctrine Cache supports.  This means that Grav supports:
+Grav uses the established and well-respected [Doctrine Cache](https://www.doctrine-project.org/projects/doctrine-cache/en/latest/index.html) library. This means that Grav supports any caching mechanism that Doctrine Cache supports.  This means that Grav supports:
 
 * **Auto** _(Default)_ - Finds the best option automatically
 * **File** - Stores in cache files in the `cache/` folder


### PR DESCRIPTION
Minor fix of a broken link on Performance & Caching page. 