### PR TITLE
Additions/corrections to Themes/Theme Configuration

### DIFF
--- a/pages/03.themes/05.theme-configuration/docs.md
+++ b/pages/03.themes/05.theme-configuration/docs.md
@@ -82,13 +82,15 @@ As well as the blueprint information, you can also easily access the current the
 
 ```
 Theme Color Option: {{ grav.theme.config.color_option }}
-or
+   or
 Theme Color Option: {{ config.theme.color_option }}
-or
+   or
 Theme Color Option: {{ theme.color_option }}
+   or
+Theme Color Option: {{ theme_var(color_option) }}
 ```
 
-And of course, the same thing in PHP is:
+In PHP you can access the current theme's configuration with:
 
 ```
 $color_option = $this->grav['theme']->config()['color_option'];

--- a/pages/03.themes/05.theme-configuration/docs.md
+++ b/pages/03.themes/05.theme-configuration/docs.md
@@ -82,12 +82,16 @@ As well as the blueprint information, you can also easily access the current the
 
 ```
 Theme Color Option: {{ grav.theme.config.color_option }}
+or
+Theme Color Option: {{ config.theme.color_option }}
+or
+Theme Color Option: {{ theme.color_option }}
 ```
 
 And of course, the same thing in PHP is:
 
 ```
-$color_option = $this->grav['theme']['config']['color_option'];
+$color_option = $this->grav['theme']->config()['color_option'];
 ```
 
 Simple!


### PR DESCRIPTION
In the docs I have come accross several ways to get the theme's configuration and also Quarks base.html.twig gave an alternative. For completeness, I have added these alternatives to the sample given in [theme-configuration](https://learn.getgrav.org/themes/theme-configuration#accessing-theme-configuration)

Also, I noticed that the sample to get the theme's configuration from within PHP does not work. I've corrected this sample.