### PR TITLE
Admin report, add advisory-section to template

### DIFF
--- a/pages/13.security/05.reports/2017-06-17/docs.md
+++ b/pages/13.security/05.reports/2017-06-17/docs.md
@@ -15,6 +15,10 @@ Summary. Eg. "REST-API is publicly exposed without authentication required."
 
 Title is "PROJECT_FULL: LEVEL, TARGET, ID", eg. `Grav Core: Less Critical, Access Bypass, CORE-2017-001`, where ID is "ID: PROJECT_SHORT-YEAR-INT(3)", eg. `CORE-2017-001`. ID should be incremented following previous report within the project, year. Date should be in [Grav-parsable format](https://learn.getgrav.org/content/headers#date).
 
+### Advisory
+
+What users should do to solve the issue or to prevent the vulnerability. Eg. "Update to v1.2.2 of Grav Core", "Change PHP settings to `safe_mode = On`", "Ensure Server-configuration prevents access via HTTP/1.1".
+
 ### Description
 
 What the vulnerability exposes, why it is insecure, and how it would be used. Eg. "Public requests to /api could modify a page with a `POST` or `PATCH` request, without being authenticated."

--- a/pages/13.security/05.reports/2018-06-11/docs.md
+++ b/pages/13.security/05.reports/2018-06-11/docs.md
@@ -1,0 +1,35 @@
+---
+title: "Grav Admin: Moderately Critical, Access Bypass, ADMIN-2018-001"
+published: true
+date: 11-07-2018
+---
+
+- ID: ADMIN-2018-001
+- Project: Grav Admin plugin
+- Date: 11-07-2018
+- Risk-level: Moderately Critical
+
+Admin tasks a have low level of access-specificity, DirectInstall especially should be allowed only by super-administrators.
+
+### Advisory
+
+Upgrade to v1.8.6 of the Admin-plugin. The vulnerability is more pertinant to sites with multiple or many users, less so for few or single users.
+
+### Description
+
+Certain tasks within the Admin-plugin interface were exposed to lower-level, registered, users. This allows users without the `admin.login` permissions to update the newsfeed, check for updates via GPM, process notifications, and reinstall packages. Users without `admin.pages` permissions could process Markdown, delete media, or change language. Users without the `admin.super` permissions, who can do all of this, could also perform direct installations via uploaded packages.
+
+Users capable of performing low-level POST requests, with authenticated access to the Admin-plugin interface, could execute any of these tasks. Whilst the majority are not critical, especially direct installations would allow remote code execution.
+
+### Versions affected
+
+Versions prior to 1.8.6 of the Admin-plugin are affected, discovered in 1.8.5.
+
+### Solution
+
+Fixed in [Admin/Classes/AdminController](https://github.com/getgrav/grav-plugin-admin/blob/e87217a2426864669cc63740620f5bd702860874/classes/admincontroller.php), lines 879-882, 931-934, 981-984, 1024-1027, 1236-1244, 1873-1875, 2202-2205, 2231-2280 at [Jul 11, 2018, 11:30 PM GMT+2](https://github.com/getgrav/grav-plugin-admin/commit/e87217a2426864669cc63740620f5bd702860874).
+
+
+### Attribution
+
+Reported by [cure53-alex](https://github.com/cure53-alex), fixed by [Andy Miller](https://github.com/rhukster).

--- a/pages/13.security/05.reports/docs.md
+++ b/pages/13.security/05.reports/docs.md
@@ -1,6 +1,6 @@
 ---
 title: Reports
-published: false
+published: true
 taxonomy:
     category: docs
 content:
@@ -18,7 +18,7 @@ twig_first: true
 
 This is the public repository for security reports for Grav. Below are the most recent reports that have been submitted and processed.
 
-{% for p in page.collection %}
+{% for p in page.collection.visible %}
   <a href="{{ p.url }}">
     <h4>{{ p.title }}</h4>
   </a>


### PR DESCRIPTION
On the basis of the recently reported and fixed security issue in [Admin 1483](https://github.com/getgrav/grav-plugin-admin/issues/1483), publish a report detailing the issue, how it was solved, and what users should do to plug the vulnerability.