### PR TITLE
Tidbits of additions, bit of issue-cleanup

### DIFF
--- a/pages/01.basics/05.grav-configuration/docs.md
+++ b/pages/01.basics/05.grav-configuration/docs.md
@@ -165,7 +165,7 @@ The **Pages** section of the `system/config/system.yaml` file is where you set a
 * **types**: List of valid page types. For example: `[txt,xml,html,htm,json,rss,atom]`
 * **append_url_extension**: Append page's extension in Page URLs (e.g. `.html` results in **/path/page.html**).
 * **expires**: Page expires time in seconds (604800 seconds = 7 days) (`no cache` is also possible).
-* **cache_control**: Can be blank for no setting, or a valid `cache-control` text value
+* **cache_control**: Can be blank for no setting, or a [valid](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) `cache-control` text value
 * **last_modified**: Set the last modified date header based on file modification timestamp. Can be set `true` or `false`.
 * **etag**: Set the etag header tag. Can be set to `true` or `false`.
 * **vary_accept_encoding**: Add `Vary: Accept-Encoding` header. Can be set to `true` or `false`.
@@ -205,7 +205,7 @@ The **Cache** section is where you can configure the site's caching settings. Yo
     - **method**: Method to check for updates in pages. Options: `file`, `folder`, `hash` and `none`. [more details](../../advanced/performance-and-caching#grav-core-caching)
 * **driver**: Select a cache driver. Options are: `auto`, `file`, `apc`, `xcache`, `redis`, `memcache`, and `wincache`.
 * **prefix**: Cache prefix string (prevents cache conflicts). Example: `g`.
-* **clear_images_by_default**: By default grav will include processed images in cache clear, this can be disabled
+* **clear_images_by_default**: By default grav will include processed images when cache clears, this can be disabled by setting this to `false`
 * **cli_compatibility**: Ensures only non-volatile drivers are used (file, redis, memcache, etc.)
 * **lifetime**: Lifetime of cached data in seconds (`0` = infinite). `604800` is 7 days.
 * **gzip**: GZip compress the page output. Can be set to `true` or `false`.

--- a/pages/02.content/02.headers/docs.md
+++ b/pages/02.content/02.headers/docs.md
@@ -71,10 +71,18 @@ Optional field, but can provide a date to automatically trigger publication. Val
 ### Expires
 
 ```ruby
-Expires: 604800
+expires: 604800
 ```
 
 Page expires time in seconds (604800 seconds = 7 days) (`no cache` is also possible).
+
+### Cache-control
+
+```ruby
+cache_control: max-age=604800
+```
+
+Can be blank for no setting, or a [valid](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) `cache-control` text value
 
 ### Unpublish Date
 

--- a/pages/02.content/03.collections/docs.md
+++ b/pages/02.content/03.collections/docs.md
@@ -252,9 +252,7 @@ Each level in the hierarchy adds two whitespaces before the variable. YAML will 
 
 ### Complex Collections
 
-With Grav **0.9.41** you can now provide multiple complex collection definitions and the resulting collection will be the sum of all the pages found from each of the collection definitions.
-
-for example:
+You can also provide multiple complex collection definitions and the resulting collection will be the sum of all the pages found from each of the collection definitions. For example:
 
 ```ruby
 content:
@@ -262,6 +260,16 @@ content:
     - '@self.children'
     - '@taxonomy':
          category: [blog, featured]
+```
+
+Additionally, you can filter the collection by using `filter: type: value`. The type can be any of the following: `published`, `non-published`, `visible`, `non-visible`, `modular`, `non-modular`, `routable`, `non-routable`, `type`, `types`, `access`. These correspond to the [Collection-specific methods](#collection-object-methods), and you can use several to filter your collection. They are all either `true` or `false`, except for `type` which takes a single template-name, `types` which takes an array of template-names, and `access` which takes an array of access-levels. For example:
+
+```ruby
+ content:
+  items: '@self.siblings'
+  filter: 
+    published: true
+    type: 'blog'
 ```
 
 ### Ordering Options
@@ -372,6 +380,7 @@ Also has several useful Collection-specific methods:
 * `Collection::key()` - Returns the current slug of the the current item
 * `Collection::remove($path)` - Removes a specific page in the collection, or current if `$path = null`
 * `Collection::order($by, $dir, $manual)` - Orders the current collection
+* `Collection::intersect` - Merge two collections, keeping items that occur in both collections (like an "AND" condition)
 * `Collection::isFirst($path)` - Determines if the page identified by path is first
 * `Collection::isLast($path)` - Determines if the page identified by path is last
 * `Collection::prevSibling($path)` - Returns the previous sibling page if possible
@@ -380,7 +389,8 @@ Also has several useful Collection-specific methods:
 * `Collection::dateRange($startDate, $endDate, $field)` - Filters the current collection with dates
 * `Collection::visible()` - Filters the current collection to include only visible pages
 * `Collection::nonVisible()` - Filters the current collection to include only non-visible pages
-* `Collection::modular()`  - Filters the current collection to include only modular pages
+* `Collection::merge()` - Merge two collections, keeping items that occur in either collection (like an "OR" condition)
+* `Collection::modular()` - Filters the current collection to include only modular pages
 * `Collection::nonModular()` - Filters the current collection to include only non-modular pages
 * `Collection::published()` - Filters the current collection to include only published pages
 * `Collection::nonPublished()` - Filters the current collection to include only non-published pages
@@ -442,7 +452,7 @@ foreach ($collection as $page) {
 }
 ```
 
-You can also use the same `evaluate()` method that the frontmatter-based page collections make use of:
+The `order()`-function can also, in addition to the `by`- and `dir`-parameters, take a `manual`- and `sort_flags`-parameter. These are [documented above](#ordering-options). You can also use the same `evaluate()` method that the frontmatter-based page collections make use of:
 
 ```
 $page = Grav::instance()['page'];

--- a/pages/03.themes/04.twig-filters-functions/docs.md
+++ b/pages/03.themes/04.twig-filters-functions/docs.md
@@ -430,19 +430,17 @@ Similar to evaluate, but will evaluate and process with Twig
 
 ##### EXIF
 
-Output a the EXIF data on an image base on it's filepath.  This requires that `media.auto_metadata_exif:` is enabled in `system.yaml`
+Output the EXIF data from an image based on its filepath. This requires that `media: auto_metadata_exif: true` is set in `system.yaml`. For example, in a Twig-template:
 
 ```
 {% verbatim %}
-{% set image = page.find('/content/media').media['sample-image.jpg'] %}
-{% set data = exif(image.filepath, true) %}
-{{ print_r(data)}}
+{% set image = page.media['sample-image.jpg'] %}
+{% set exif = exif(image.filepath, true) %}
+{{ exif.MaxApertureValue }}
 {% endverbatim %}
 ```
 
-
-{% set data = exif(image.filepath, false) %}
-Outputs **{{ dump(data)}}**
+This would write the `MaxApertureValue`-value set in the camera, for example "40/10". You can always use `{% verbatim %}{{ dump(exif)}}{% endverbatim %}` to show all the available data in the debugger.
 
 ##### Get Cookie
 

--- a/pages/10.cookbook/01.general-recipes/docs.md
+++ b/pages/10.cookbook/01.general-recipes/docs.md
@@ -136,6 +136,8 @@ Basically, this extends the standard `partials/base.html.twig` (assuming your th
 
 The next section simply loops over all the media of the page that are **images**.  We are outputting these in an unordered list to make the output semantic, and easy to style with CSS.  we are assigning each image the variable name `image` and then we are able to perform a simple `cropResize()` method to resize the image to something suitable, and then below it, we provide an information section with the `title` and `description`.
 
+You could make a more advanced gallery-implementation by using creating filters for camera-data, with the [EXIF](/themes/twig-filters-functions#exif)-function.
+
 ### Render content in columns
 
 ##### Problem:


### PR DESCRIPTION
- [x] Document optional collection ordering PHP flags getgrav/grav#1640
	- Added under /content/collections#php-collections
- [x] Added cache_control system and page override getgrav/grav#1591
	- Added reference-link to /basics/grav-configuration#pages
	- Added /content/headers#cache-control
- [x] clear_images_by_default cache option getgrav/grav#1481
	- Clarified description in /basics/grav-configuration#pages
- [x] Collection::intersect() getgrav/grav#1605
	- Added under /content/collections#collection-object-methods
- [x] Collection::merge() method
	- Added under /content/collections#collection-object-methods
- [x] Page::collection() filtering
	- Added under /content/collections#complex-collections, with a bit of cleanup
- [x] Document EXIF support in Grav (and in capabilities)
	- Clarified /themes/twig-filters-functions#exif
	- Added note at the end of /cookbook/general-recipes#creating-a-simple-gallery
- [x] document not being able to scroll caused by cloudlare. getgrav/grav-plugin-admin#808 (comment)
	- Done in #397
	- Duplicated under Admin Plugin and Cookbook headers
- [x] Document adding custom form fields with examples..
	- Done in #401
- [x] Document range field
	- Done in [7e0dcbc](https://github.com/getgrav/grav-learn/commit/7e0dcbc70a51a32662f60ea1c4927aeff04ff8f7)
- [x] Tutorial on how to create a split menu system (vertical menu?)
	- Duplicated under Cookbook header
- [x] Tutorial walkthrough covering going from and HTML site/design to Grav theme
	- Duplicated under Cookbook header

#356 needs some cleanup to remove completed tasks, they're not really needed.