### PR TITLE
Add link to further form email options in email plugin README

### DIFF
--- a/pages/06.forms/02.forms/04.reference-form-actions/docs.md
+++ b/pages/06.forms/02.forms/04.reference-form-actions/docs.md
@@ -38,6 +38,8 @@ Antimatter sets it to
 
 In short, it just loops the values and prints them in the email body.
 
+!! Refer to the email plugin documentation for additional [important form email options](https://github.com/getgrav/grav-plugin-email#emails-sent-with-forms) including [multipart message bodies](https://github.com/getgrav/grav-plugin-email#multi-part-mime-messages) (good for anti-spam scores), `reply_to`, and [attachments](https://github.com/getgrav/grav-plugin-email#sending-attachments).
+
 ##### Dynamic email attribute
 
 If you want for example to set the `email.from` field from a Form input, you can get its content and use it in this way:


### PR DESCRIPTION
Covers [`reply_to` in topics to be documented](https://github.com/getgrav/grav-learn/issues/356#issuecomment-376400810).