### PR TITLE
Make the best practice explicit

### DIFF
--- a/pages/03.themes/05.theme-configuration/docs.md
+++ b/pages/03.themes/05.theme-configuration/docs.md
@@ -4,47 +4,11 @@ taxonomy:
     category: docs
 ---
 
-Theme configuration works in a similar fashion to all the other configuration settings in Grav. You can provide settings for a theme configuration file for your theme with the filename `<themename>.yaml` in the root of your theme folder. These variables can be accessed in your template files.
+As of Grav 1.1, you can easily access theme configuration and blueprint information from your Twig and PHP files.
 
-It is **strongly** recommended not to actually change the theme's YAML file, but to override the settings in the `user/config` folder. This will ensure that the theme's original settings remain intact, allowing you to quickly access the changes and/or revert back whenever necessary.
+## Accessing Theme Blueprint Information
 
-For example, let us consider the Antimatter theme.  By default, there is a file called `antimatter.yaml` in the theme's root folder. The contents of this configuration file look like this:
-
-```
-enabled: true
-color: blue
-```
-
-This is a simple file, but it provides you an idea of what you can do with theme configuration settings. Let us provide an override for these settings plus a new one.
-
-So, create a file in the following location: `user/config/themes/antimatter.yaml`.  In this file put the following contents:
-
-```
-color: red
-info: Grav is awesome!
-```
-
-Then in your theme, you can add something like this:
-
-```
-<h1 style="color:{{ config.themes.antimatter.color }}">{{ config.themes.antimatter.info }}</h1>
-```
-
-This should render out as:
-
-<h1 style="color:red">Grav is awesome!</h1>
-
-The sky is the limit regarding the configuration of your themes.  You can use them for whatever you like! :)
-
-## Accessing Theme Info
-
-As of Grav 1.1, you can easily access theme configuration and blueprint-related information.  To access information via Twig from the `blueprints.yaml` such as theme name you can simply use:
-
-```
-{{ grav.theme.name }}
-```
-
-For a given example `blueprints.yaml` configuration of:
+Information from the currently active theme's `blueprints.yaml` file can be had from the `grav.theme` object. Let's use the following `blueprints.yaml` file as an example:
 
 ```
 name: Antimatter
@@ -78,23 +42,58 @@ $theme_license = $this->grav['theme']['license'];
 
 ## Accessing Theme Configuration
 
-As well as the blueprint information, you can also easily access the current theme configuration with:
+Theme's have configuration files, too. A theme's configuration file is named `<themename>.yaml`. The default file lives in the theme's root folder (`user/themes/<themename>`). 
+
+It is **strongly** recommended not to actually change the theme's default YAML file but to override the settings in the `user/config` folder. This will ensure that the theme's original settings remain intact, allowing you to quickly access the changes and/or revert back whenever necessary.
+
+For example, let us consider the Antimatter theme.  By default, there is a file called `antimatter.yaml` in the theme's root folder. The contents of this configuration file look like this:
 
 ```
-Theme Color Option: {{ grav.theme.config.color_option }}
-   or
+enabled: true
+color: blue
+```
+
+This is a simple file, but it provides you an idea of what you can do with theme configuration settings. Let us override these settings and add a new one.
+
+So, create a file in the following location: `user/config/themes/antimatter.yaml`.  In this file put the following contents:
+
+> *I note that `enabled` is not repeated here. If the config files are merged and not simply replaced, then that should be explicitly stated.*
+
+```
+color: red
+info: Grav is awesome!
+```
+
+Then in your theme templates you can access these variables using the `grav.theme.config` object:
+
+```
+<h1 style="color:{{ grav.theme.config.color }}">{{ grav.theme.config.info }}</h1>
+```
+
+This should render out as:
+
+<h1 style="color:red">Grav is awesome!</h1>
+
+In PHP you can access the current theme's configuration with:
+
+```
+$color = $this->grav['theme']->config()['color'];
+```
+
+Simple! The sky is the limit regarding the configuration of your themes.  You can use them for whatever you like! :)
+
+### Alternative Notation
+
+The following aliases also work:
+
+```
 Theme Color Option: {{ config.theme.color_option }}
    or
 Theme Color Option: {{ theme.color_option }}
    or
 Theme Color Option: {{ theme_var(color_option) }}
+   or
+Theme Color Option: {{ grav.themes.antimatter.color_option }} [AVOID!]
 ```
 
-In PHP you can access the current theme's configuration with:
-
-```
-$color_option = $this->grav['theme']->config()['color_option'];
-```
-
-Simple!
-
+**Even though `grav.themes.<themename>` is supported, it should be avoided because it makes it impossible to inherit the theme properly.**


### PR DESCRIPTION
The changes appear more extensive because I did some reorganizing to make it flow more logically.

The primary change, though, is to minimize the `grav.themes.<themename>` approach to accessing theme configuration. It makes proper inheritance impossible. The best practice is `grav.theme.config` and is parallel with how you access the blueprint info.

I used a blockquote to flag a question, though. In your revised config file, you don't repeat `enabled`. If the two config files get merged as opposed to simply replaced, that needs to be explicitly stated. That blockquote needs to be edited before merging. Let me know what you'd like me to do with it.