### PR TITLE
fix php-fpm service name typo in ubuntu-18.04 vps page

### DIFF
--- a/pages/09.webservers-hosting/02.vps/ubuntu-18.04/default.md
+++ b/pages/09.webservers-hosting/02.vps/ubuntu-18.04/default.md
@@ -196,7 +196,7 @@ Now all we have to do is restart Nginx and the php7-fpm process and test to ensu
 
 ```
 $ service nginx restart
-$ service php-fpm7.2 restart
+$ service php7.2-fpm restart
 ```
 
 Now point your browser at your server: `http://{{ page.header.localname }}` and you should see the text: **Working!**


### PR DESCRIPTION
I was following the documentation on [this](https://learn.getgrav.org/webservers-hosting/vps/digitalocean) page and discovered that while the binary is called **php-fpm7.2** (verified by running `which`), the service created after install is called, for whatever reason, **php7.2-fpm**. It took me a few minutes to figure out why the command `service php-fpm7.2 restart` failed, so I hope this saves someone some time.

Is anyone able to reproduce this? I just created a DigitalOcean Ubuntu 18 droplet and followed the steps from there.
![php-fpm](https://user-images.githubusercontent.com/24627271/45248314-f5b6aa00-b2d4-11e8-8c32-b5f0225bb5f9.png)
