### PR TITLE
Fix generic user variable in copy-paste Nginx config

### DIFF
--- a/pages/09.webservers-hosting/02.vps/ubuntu-18.04/default.md
+++ b/pages/09.webservers-hosting/02.vps/ubuntu-18.04/default.md
@@ -138,7 +138,7 @@ server {
     index index.html index.php;
 
     ## Begin - Server Info
-    root /home/USER/www/html;
+    root /home/grav/www/html;
     server_name localhost;
     ## End - Server Info
 


### PR DESCRIPTION
The `root /home/USER/www/html;` line breaks the Nginx install when following the tutorial and blindly copy-pasting the config.

It has to be `root /home/grav/www/html;` to use the grav account created earlier in the tutorial, like in the [16.04 tutorial version](https://github.com/getgrav/grav-learn/blob/develop/pages/09.webservers-hosting/02.vps/ubuntu-16.04/default.md).

With this fix the guide worked flawlessly on a Droplet that was intially configured with LAMP. Thanks!