### PR TITLE
Update PHP translations

### DIFF
--- a/pages/02.content/11.multi-language/docs.md
+++ b/pages/02.content/11.multi-language/docs.md
@@ -264,19 +264,19 @@ Il y a 12 singes dans le Zoo de Londres
 As well as the Twig filter and functions you can use the same approach within your Grav plugin:
 
 [prism classes="language-php line-numbers"]
-$translation = $grav['language']->translate(['HEADER.MAIN_TEXT']);
+$translation = $this->grav['language']->translate(['HEADER.MAIN_TEXT']);
 [/prism]
 
 You can also specify a language:
 
 [prism classes="language-php line-numbers"]
-$translation = $grav['language']->translate(['HEADER.MAIN_TEXT'], 'fr');
+$translation = $this->grav['language']->translate(['HEADER.MAIN_TEXT'], 'fr');
 [/prism]
 
 To translate a specific item in an array use:
 
 [prism classes="language-php line-numbers"]
-$translation = $grav['language']->translateArray('MONTHS_OF_THE_YEAR', 3);
+$translation = $this->grav['language']->translateArray('MONTHS_OF_THE_YEAR', 3);
 [/prism]
 
 ### Plugin and Theme Language Translations


### PR DESCRIPTION
Enabling language support in my plugin did not work like this: 
`$grav['language']->translate(['PLUGIN_ANTISPAM.NOSCRIPT'])`

But Ole Vik helped me out in the [forum](https://discourse.getgrav.org/t/language-support-for-a-plugin-undefined-variable-grav/) and I got it to work in this form: 
`$this->grav['language']->translate(['PLUGIN_ANTISPAM.NOSCRIPT'])`. 

I changed this bit in the document section on PHP translations where I had the first version from.