### PR TITLE
Custom form processing missing RocketTheme?

### DIFF
--- a/pages/06.forms/02.forms/04.reference-form-actions/docs.md
+++ b/pages/06.forms/02.forms/04.reference-form-actions/docs.md
@@ -200,6 +200,7 @@ In its main PHP file, register for the event `onFormProcessed`
 [prism classes="language-php line-numbers"]
 namespace Grav\Plugin;
 use Grav\Common\Plugin;
+use RocketTheme\Toolbox\Event\Event;
 
 class EmailPlugin extends Plugin
 {


### PR DESCRIPTION
I have fixed the below error by adding:
`use RocketTheme\Toolbox\Event\Event;`
before class definition.
Argument 1 passed to Grav\Plugin\AirtablePlugin::onFormProcessed() must be an instance of Grav\Plugin\Event, instance of RocketTheme\Toolbox\Event\Event given, called in /home/grav/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php on line 212