### PR TITLE
Update docs.md for environment configuration

### DIFF
--- a/pages/08.advanced/04.environment-config/docs.md
+++ b/pages/08.advanced/04.environment-config/docs.md
@@ -79,5 +79,5 @@ user/config/themes/antimatter.yaml
 Can be overridden for any environment, say some production site (`http://www.mysite.com`):
 
 [prism classes="language-bash command-line"]
-www.mysite.com/config/themes/antimatter.yaml
+user/www.mysite.com/config/themes/antimatter.yaml
 [/prism]


### PR DESCRIPTION
Makes explicit that theme overrides are located inside the `user` folder, just as in the plugin and system override examples given above.