### PR TITLE
Minor typos in docs.md

### DIFF
--- a/pages/03.themes/02.theme-tutorial/docs.md
+++ b/pages/03.themes/02.theme-tutorial/docs.md
@@ -244,7 +244,7 @@ If you look at the `templates/partials/base.html.twig` you will see the meat of 
 
 Please read over the code in the `base.html.twig` file to try to understand what is going on.  There are several key things to note:
 
-1. A `theme_config` variable is set with the theme configuration.  Because Twig doesn't work well with dashes retrieve variables with dashes (e.g. `config.themes.my-theme`), we use the `attribute()` Twig function to dynamically retrieve the `my-theme` data from `config.themes`.
+1. A `theme_config` variable is set with the theme configuration.  Because Twig doesn't work well with dashes, to retrieve variables with dashes (e.g. `config.themes.my-theme`), we use the `attribute()` Twig function to dynamically retrieve the `my-theme` data from `config.themes`.
 
 1. The `<html lang=...` item is set based on Grav's active language if enabled, else it uses the `default_lang` as set in the `theme_config`.
 

--- a/pages/03.themes/02.theme-tutorial/docs.md
+++ b/pages/03.themes/02.theme-tutorial/docs.md
@@ -78,7 +78,7 @@ SUCCESS theme mytheme -> Created Successfully
 Path: /www/user/themes/my-theme
 [/prism]
 
-The DevTools command tells you where this new template was created. This created template is fully functional but also very simple.  You will want to modify this to suite your needs.
+The DevTools command tells you where this new template was created. This created template is fully functional but also very simple.  You will want to modify this to suit your needs.
 
 In order to see your new theme in action, you will need to change the default theme from `quark` to `my-theme`, so edit your `user/config/system.yaml` and change it:
 


### PR DESCRIPTION
The help page under 03.Themes -> 02.Theme tutorial had two minor typos that I fixed.