### PR TITLE
Add link to download the Heroku CLI

### DIFF
--- a/pages/09.webservers-hosting/03.paas/02.heroku/docs.md
+++ b/pages/09.webservers-hosting/03.paas/02.heroku/docs.md
@@ -17,7 +17,7 @@ Let's see how to install Grav on Heroku.
 
 First, sign up for Heroku.
 
-Download the Heroku Toolbelt, which is a command-line utility needed to deploy create and deploy your site.
+Download the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli), which is a command-line utility needed to deploy create and deploy your site.
 
 Once installed, type
 


### PR DESCRIPTION
Currently there is only a mention of the "Heroku Toolbelt" with is no longer supported. I suggest changing this to a link to the "Heroku CLI", which is actually what a user would need.