### PR TITLE
Added selectize field example

### DIFF
--- a/pages/06.forms/01.blueprints/01.fields-available/docs.md
+++ b/pages/06.forms/01.blueprints/01.fields-available/docs.md
@@ -881,6 +881,14 @@ Example:
 [prism classes="language-yaml line-numbers"]
 taxonomies:
     type: selectize
+    selectize:
+        options:
+            - text: "test"
+              value: "real value 1"
+            - text: "test-2"
+              value: "real value 2"
+            - text: "test-3"
+              value: "real value 3"
     size: large
     label: PLUGIN_ADMIN.TAXONOMY_TYPES
     classes: fancy


### PR DESCRIPTION
An example of how preset a group of pre-built entries to type was missing.
I added one, based on the animated screenshot already provided by the documentation.
Sources : https://github.com/getgrav/grav/issues/2149