### PR TITLE
Add note that operation: add now requires a static filename to be defined

### DIFF
--- a/pages/06.forms/02.forms/04.reference-form-actions/docs.md
+++ b/pages/06.forms/02.forms/04.reference-form-actions/docs.md
@@ -157,6 +157,16 @@ The body is taken from the theme's `templates/forms/data.html.twig` file, provid
 
 ! the `operation` can be either `create` (default) to create a new file per-form-submission or `add` to append to a single file.
 
+! note that the `add` operation now requires a static filename: to be defined see the example below.
+
+[prism classes="language-yaml line-numbers"]
+process:
+    - save:
+        filename: feedback.txt
+        body: "{% include 'forms/data.txt.twig' %}"
+        operation: add
+[/prism]
+
 ### Captcha
 
 To also validate the captcha server-side, add the captcha process action.


### PR DESCRIPTION
since an update to the forms plugin the functionality of operation:add was changed to throw an error if filename: not defined, this wasn't reflected in the documnentation https://github.com/getgrav/grav-plugin-form/issues/324