### PR TITLE
Added more details to form reset option

### DIFF
--- a/pages/06.forms/02.forms/04.reference-form-actions/docs.md
+++ b/pages/06.forms/02.forms/04.reference-form-actions/docs.md
@@ -194,7 +194,8 @@ process:
 By default, the form is not cleared after the submit. So if you don't have a `display` action and the user is sent back to the form page, it's still filled with the data entered. If you want to avoid this, add a `reset` action:
 
 [prism classes="language-yaml"]
-reset: true
+process:
+    - reset: true
 [/prism]
 
 ## Custom Actions


### PR DESCRIPTION
It was not very clear where should `reset: true` be placed in the `form`. I have found this answer - https://discourse.getgrav.org/t/reset-a-form/369, which seem to provide a correct solution.