### PR TITLE
Include documentation of url_taxonomy_filters

### DIFF
--- a/pages/02.content/03.collections/docs.md
+++ b/pages/02.content/03.collections/docs.md
@@ -253,6 +253,8 @@ content:
 
 Each level in the hierarchy adds two whitespaces before the variable. YAML will allow you to use as many spaces as you want here, but two is standard practice. In the above example, both the `category` and `tag` variables are set under `@taxonomy`.
 
+Page collections will automatically by filtered by taxonomy when one has been set in the URL (e.g. /archive/category:news). This enables you to build a single blog archive template but filter the collection dynamically using the URL. If your page collection should ignore the taxonomy set in the URL use the flag `url_taxonomy_filters:false` to disable this feature.
+
 ### Complex Collections
 
 You can also provide multiple complex collection definitions and the resulting collection will be the sum of all the pages found from each of the collection definitions. For example:


### PR DESCRIPTION
I've recently had problems with site-wide navigation that utilizes page.collection to generate the list of pages. On pages where there's an active taxonomy filter (e.g. our blog archive page) the menu disappears. This is due to the fact that all page collection objects in a template are affected by a taxonomy filter in the URL - see https://github.com/getgrav/grav/issues/2696

This doesn't seem to be documented anywhere so I though I'd add something. Feel free to make suggestions if you feel it would be better placed elsewhere!