### PR TITLE
Fix incorrect twig example access

### DIFF
--- a/pages/01.basics/05.grav-configuration/docs.md
+++ b/pages/01.basics/05.grav-configuration/docs.md
@@ -601,7 +601,7 @@ Let's break down the elements of this sample file:
 | **summary:** | |
 | ... **size:** | A variable to override the default number of characters that can be used to set the summary size when displaying a portion of content |
 | **routes:** | This is a basic map that can provide simple URL alias capabilities in Grav.  If you browse to `/something/else` you will actually be sent to `/blog/sample-3`. Feel free to edit, or add your own as needed. **Regex Replacements** (`(.*) - $1`) are now supported at the end of route aliases.  You should put these at the bottom of the list for optimal performance |
-| **(custom options)** | You can create any option you like in this file and a good example is the `blog: route: '/blog'` option that is accessible in your Twig templates with `system.blog.route` |
+| **(custom options)** | You can create any option you like in this file and a good example is the `blog: route: '/blog'` option that is accessible in your Twig templates with `site.blog.route` |
 [/div]
 
 !! For most people, the most important element of this file is the `Taxonomy` list.  The taxonomies in this list **must** be defined here if you wish to use them in your content.


### PR DESCRIPTION
`system.blog.route` should be `site.blog.route` because we are providing an example of custom options in `user/config/site.yaml`