### PR TITLE
Added documentation for twig extensions preg_split / preg_match

### DIFF
--- a/pages/03.themes/04.twig-filters-functions/docs.md
+++ b/pages/03.themes/04.twig-filters-functions/docs.md
@@ -252,6 +252,18 @@ Converts a string to the English plural version
 
 `'person'|pluralize` <i class="fa fa-long-arrow-right"></i> **{{ 'person'|pluralize }}**
 
+[version=17]
+#### Preg Split
+
+Wrapper for PHP [preg_split()](https://www.php.net/manual/en/function.preg-split.php) that splits a text by a pattern given as regular expression.
+[/version]
+
+[version=17]
+#### Preg Match
+
+Wrapper for PHP [preg_match()](https://www.php.net/manual/en/function.preg-match.php) that matches a text by a pattern given as expression pattern. Returns the matches if there is at least one or false if not.
+[/version]
+
 [version=16]
 #### Print Variable
 

--- a/pages/03.themes/04.twig-filters-functions/docs.md
+++ b/pages/03.themes/04.twig-filters-functions/docs.md
@@ -255,7 +255,7 @@ Converts a string to the English plural version
 [version=17]
 #### Preg Match
 
-Wrapper for PHP [preg_match()](https://www.php.net/manual/en/function.preg-match.php) that matches a text by a pattern given as expression pattern. Returns the matche(s) if there is at least one accordance or `false` if not.
+Wrapper for PHP [preg_match()](https://www.php.net/manual/en/function.preg-match.php) that matches a text by a pattern given as regular expression. Returns the matche(s) if there is at least one accordance or `false` if not.
 [/version]
 
 [version=17]

--- a/pages/03.themes/04.twig-filters-functions/docs.md
+++ b/pages/03.themes/04.twig-filters-functions/docs.md
@@ -253,15 +253,15 @@ Converts a string to the English plural version
 `'person'|pluralize` <i class="fa fa-long-arrow-right"></i> **{{ 'person'|pluralize }}**
 
 [version=17]
-#### Preg Split
-
-Wrapper for PHP [preg_split()](https://www.php.net/manual/en/function.preg-split.php) that splits a text by a pattern given as regular expression.
-[/version]
-
-[version=17]
 #### Preg Match
 
 Wrapper for PHP [preg_match()](https://www.php.net/manual/en/function.preg-match.php) that matches a text by a pattern given as expression pattern. Returns the matche(s) if there is at least one accordance or `false` if not.
+[/version]
+
+[version=17]
+#### Preg Split
+
+Wrapper for PHP [preg_split()](https://www.php.net/manual/en/function.preg-split.php) that splits a text by a pattern given as regular expression.
 [/version]
 
 [version=16]

--- a/pages/03.themes/04.twig-filters-functions/docs.md
+++ b/pages/03.themes/04.twig-filters-functions/docs.md
@@ -261,7 +261,7 @@ Wrapper for PHP [preg_split()](https://www.php.net/manual/en/function.preg-split
 [version=17]
 #### Preg Match
 
-Wrapper for PHP [preg_match()](https://www.php.net/manual/en/function.preg-match.php) that matches a text by a pattern given as expression pattern. Returns the matches if there is at least one or false if not.
+Wrapper for PHP [preg_match()](https://www.php.net/manual/en/function.preg-match.php) that matches a text by a pattern given as expression pattern. Returns the matche(s) if there is at least one accordance or `false` if not.
 [/version]
 
 [version=16]


### PR DESCRIPTION
As there is already a pending PR for this functionality (getgrav/grav#2788) I also decided to write/update the corresponding documentation for twig filters / functions. I added the `<version>`  tag and used as target version `17` as it is not a big change and might already get merged into 1.7 as well. This might be subject to change. Just let me know and I will update the target version.