### PR TITLE
Corrected attributes for Number field

### DIFF
--- a/pages/06.forms/02.forms/02.fields-available/docs.md
+++ b/pages/06.forms/02.forms/02.fields-available/docs.md
@@ -512,17 +512,18 @@ Example:
 header.count:
   type: number
   label: 'How Much?'
-  min: 10
-  max: 360
-  step: 10
+  validate:
+    min: 10
+    max: 360
+    step: 10
 [/prism]
 
 [div class="table table-keycol"]
 | Attribute | Description                                       |
 | :-----    | :-----                                            |
-| `min` | minimum value |
-| `max`  | maximum value  |
-| `step`  | which increpemts to step up  |
+| `validate.min` | minimum value |
+| `validate.max`  | maximum value  |
+| `validate.step`  | which increpemts to step up  |
 [/div]
 
 [div class="table"]


### PR DESCRIPTION
The min, max, and step attributes need to be within the `validation` collection or they don't work. As per the number field template:

```
{% block input_attributes %}
    type="number"
    {% if field.validate.min is defined %}min="{{ field.validate.min }}"{% endif %}
    {% if field.validate.max is defined %}max="{{ field.validate.max }}"{% endif %}
    {% if field.validate.step is defined %}step="{{ field.validate.step }}"{% endif %}
    {{ parent() }}
{% endblock %}
```