### PR TITLE
Add Missing access levels, more info on super

### DIFF
--- a/pages/05.admin-panel/09.faq/docs.md
+++ b/pages/05.admin-panel/09.faq/docs.md
@@ -79,13 +79,22 @@ Every user yaml file has an `access` property. By setting this property appropri
 Here are the currently supported access levels explained:
 
 - `admin.login`: allows a user to login to the admin
-- `admin.super`: grants a user super admin powers, allowing access to all the admin interface and functionality
+- `admin.super`: grants a user super admin powers, allowing access to all the admin interface and functionality ignoring other access properties except `admin.login`
 - `admin.pages`: allows a user to view pages, edit them and add new ones
 - `admin.maintenance`: allows a user to update Grav from the admin side, check for updates and clear the cache
 - `admin.plugins`: allows a user to access the plugins functionality, edit the plugins settings, disable plugins or add new ones
 - `admin.themes`: allows a user to access the themes functionality, edit theme settings, change themes and add new ones
 - `admin.statistics`: allows a user to see the site statistics
 - `admin.cache`: allows a user to clear the cache
+- `admin.configuration`: allows a user to access the configuration of the instance. Permission for the individual parts have to be given separately via the variables listed below. Only enabling the "sub-variables" without enabling this variable will not enable the configuration menu for the user.
+  - `admin.configuration_system`: allows a user to change the system settings
+  - `admin.configuration_site`: allows a user to change the site settings
+  - `admin.configuration_media`: allows a user to edit the available media types
+  - `admin.configuration_info`: allows a user to view the info about this instance
+- other access levels, which have not yet been explained are:
+  - `admin.tools`
+  - `admin.settings`
+  - `admin.users`
 
 !! Changes made to a user.yaml file while that user is logged-in will only take effect after they log out and back in again.
 


### PR DESCRIPTION
I added a more complete description on how `admin.super` interacts with other access levels and added all levels that are shown in the User Page when `admin.super` is enabled. however I could only find out the function of the configuration levels. Yet I added all levels to encourage others to add the missing information.