### PR TITLE
broken and outdated link

### DIFF
--- a/pages/04.plugins/02.plugin-tutorial/docs.md
+++ b/pages/04.plugins/02.plugin-tutorial/docs.md
@@ -360,4 +360,4 @@ public function onPageContentProcessed(Event $event)
 
 ## Implementing CLI in your Plugin
 
-Plugins have also the capability of integrating with the `bin/plugin` command line to execute tasks. You can follow the [advanced tutorial](/advanced/grav-cli-plugin) if you desire to implement such functionality.
+Plugins have also the capability of integrating with the `bin/plugin` command line to execute tasks. You can follow the [plugin CLI documentation](/cli-console/grav-cli-plugin#developers-integrate-the-cli-in-plugin) if you desire to implement such functionality.


### PR DESCRIPTION
looks like the CLI plugin doc moved. This change updates the link to the 'right' spot