### PR TITLE
Fix path for user blueprints

### DIFF
--- a/pages/06.forms/01.blueprints/04.example-page-blueprint/docs.md
+++ b/pages/06.forms/01.blueprints/04.example-page-blueprint/docs.md
@@ -141,7 +141,7 @@ In order for the Admin Plugin to pick up the blueprints, and thus show the new P
 
 #### In the User Blueprints folder
 
-Put them in `user/blueprints/pages/`. This is a good place to put them when you simply want your blueprints to be present in your site.
+Put them in `user/blueprints/`. This is a good place to put them when you simply want your blueprints to be present in your site.
 
 #### In the Theme
 


### PR DESCRIPTION
The blueprints should be stored in `user/blueprints/`, adding a pages directory doesn't seem to work.