### PR TITLE
Update docs.md

### DIFF
--- a/pages/02.content/02.headers/docs.md
+++ b/pages/02.content/02.headers/docs.md
@@ -538,6 +538,6 @@ metadata:
     description: Give your page a powerup with Grav!
 [/prism]
 
-! If a header is defined in both frontmatter.yaml and in page frontmatter, the page values is used, frontmatter.yaml values are overrided.
+! If a header is defined in both frontmatter.yaml and in page frontmatter, the page values is used, frontmatter.yaml values are overridden.
 
 !!!! Utilizing frontmatter.yaml is a file-side feature and is **not supported** by the admin plugin.


### PR DESCRIPTION
Changed grammatical error: "overrided."

The correct grammar tense for this is "overridden." 