### PR TITLE
typo fixed

### DIFF
--- a/pages/11.troubleshooting/02.server-error/docs.md
+++ b/pages/11.troubleshooting/02.server-error/docs.md
@@ -25,7 +25,7 @@ Possible reasons include:
 The first thing you should do is flush the cache to ensure that the configuration is up to date:
 
 [prism classes="language-bash command-line"]
-bin/grav clear-cache
+bin/grav clearcache
 [/prism]
 
 !! Before moving on, make sure that you do not have other file permission issues like this.


### PR DESCRIPTION
If the command "bin/grav clear-cache" is executed, the message is displayed:
`Command "clear-cache" is not defined ` 
`Do you want to run "clearcache" instead?  (yes/no) [no]:`  

The proposed change fixes that.