### PR TITLE
section should be h2

### DIFF
--- a/pages/06.forms/01.blueprints/07.advanced-features/docs.md
+++ b/pages/06.forms/01.blueprints/07.advanced-features/docs.md
@@ -246,7 +246,7 @@ In the example above, we used the name of another field to set the ordering. In 
 
 !! When ordering fields in a page blueprint, you still need to reference the field names prefixed with `header.`, eg: `header.title` for the ordering to work.
 
-# Creating new form field type
+## Creating new form field type
 
 If you create a special form field type, which needs a special handling in blueprints, there is a plugin function that you can use.
 


### PR DESCRIPTION
I noticed this section had no generated link next to its title and that it's the only h1 section (page title is also h1). Guessing it should be h2 like the others.