### PR TITLE
Added warning/note for configuring localhost environment

### DIFF
--- a/pages/08.advanced/04.environment-config/docs.md
+++ b/pages/08.advanced/04.environment-config/docs.md
@@ -41,6 +41,8 @@ If your production server was reachable via `http://www.mysite.com` then you cou
 
 Of course, you are not limited to changes to `system.yaml`, you can actually provide overrides for **any** Grav setting in the `site.yaml` or even in any [plugin configuration](../../plugins/plugin-basics)!
 
+!! If you are using the Grav [Scheduler](/advanced/scheduler), be aware of it using the `localhost` environment and therefore its configuration.
+
 #### Plugin Overrides
 
 To override a plugin configuration YAML file is simply the same process as overriding a regular file.   If the standard configuration file is located in:


### PR DESCRIPTION
We noticed that the Grav Scheduler is using the configuration defined for `localhost`. From my point of view that is exactly the right behaviour, but it led to some nasty bug on our site. I think it is important to make sure other users are aware of this behaviour.