### PR TITLE
Correct http_accept_language configuration example

### DIFF
--- a/pages/02.content/11.multi-language/docs.md
+++ b/pages/02.content/11.multi-language/docs.md
@@ -127,7 +127,7 @@ For this to function you must enable the option in your `user/system.yaml` file 
 
 [prism classes="language-yaml line-numbers"]
 languages:
-  http_accept_language: false
+  http_accept_language: true
 [/prism]
 
 


### PR DESCRIPTION
> For this to function you must **enable** the option in your `user/system.yaml` file in the `languages:` section: