### PR TITLE
Change '@extends' to extends@

### DIFF
--- a/pages/06.forms/01.blueprints/04.example-page-blueprint/docs.md
+++ b/pages/06.forms/01.blueprints/04.example-page-blueprint/docs.md
@@ -14,7 +14,7 @@ This will use the default page form, and append a text field to the **Advanced**
 
 [prism classes="language-yaml line-numbers"]
 title: Gallery
-'@extends':
+extends@:
     type: default
     context: blueprints://pages
 


### PR DESCRIPTION
Looking at [the other docs](https://learn.getgrav.org/16/forms/blueprints/advanced-features#extending-base-type-extendsat) it should be possible to place the @ last.

If I may ask a question:
What is the difference between `context: blueprints://pages` and `context: blueprints://`? What is the default and what is the correct value for a page template? It seems to work both for me.