### PR TITLE
Correct yaml linter parameter

### DIFF
--- a/pages/08.advanced/09.grav-development/02.grav-17-upgrade-guide/docs.md
+++ b/pages/08.advanced/09.grav-development/02.grav-17-upgrade-guide/docs.md
@@ -410,7 +410,7 @@ Added new configuration option `security.sanitize_svg` to remove potentially dan
 ### Used Libraries
 
 * Updated Symfony Components to 4.4, please update any deprecated features in your code
-* **BC BREAK** Please run `bin/grav yamllinter -f user://` to find any YAML parsing errors in your site (including your plugins and themes).
+* **BC BREAK** Please run `bin/grav yamllinter` to find any YAML parsing errors in your site (including your plugins and themes).
 
 ## PLUGINS
 


### PR DESCRIPTION
"The "-f" option does not exist."

I guess the option is not relevant anymore? The linter did found an issue in my theme blueprint, so it seems to work without that param.

The command says:
```
yamllinter [-e|--env [ENV]]
```