### PR TITLE
Added missing textlength documentation

### DIFF
--- a/pages/06.forms/02.forms/02.fields-available/docs.md
+++ b/pages/06.forms/02.forms/02.fields-available/docs.md
@@ -984,6 +984,7 @@ header.content:
 | [validate.pattern](#common-fields-attributes)  |
 | [validate.message](#common-fields-attributes)  |
 [/div]
+
 ---
 
 ### Toggle Field
@@ -1028,6 +1029,7 @@ summary.enabled:
 | [validate.type](#common-fields-attributes)     |
 | [disabled](#common-fields-attributes)          |
 [/div]
+
 ---
 
 ### Url Field

--- a/pages/06.forms/02.forms/02.fields-available/docs.md
+++ b/pages/06.forms/02.forms/02.fields-available/docs.md
@@ -383,6 +383,15 @@ header.email:
   label: Email
 [/prism]
 
+[div class="table table-keycol"]
+| Attribute | Description                                       |
+| :-----    | :-----                                            |
+| `minlength` | minimum text length |
+| `maxlength`  | maximum text length  |
+| `validate.min` | same as minlength |
+| `validate.max`  | same as maxlength  |
+[/div]
+
 [div class="table"]
 | Common Attributes Allowed                      |
 | :-----                                         |
@@ -427,7 +436,6 @@ my_files:
 | `multiple`    | Can be `true` or `false`, when set to **true**, multiple files can be selected at the same time                                                                                                                                                                                                                                                                                                                                                                                          |
 | `destination` | Can be either **@self**, **@page:/route** or **local/rel/path/**. <br>Set to **@self**, the files will be uploaded where the form has been declared (current .md). <br>Using **@page:/route** will upload to the specified route of a page, if exists (e.g., **@page:/blog/a-blog-post**). <br>Set to **'local/rel/path'**: Can be any path relative to the Grav instance. For instance, `user/data/files`. If the path doesn't exist, it will get created, so make sure it is writable. |
 | `accept`      | Takes an array of MIME types that are allowed. For instance to allow only gifs and mp4 files: `accept: ['image/gif', 'video/mp4']`                                                                                                                                                                                                                                                                                                                                                       |
-
 [/div]
 
 !!! The File field in the admin is a bit different, allowing also to delete a file uploaded to a form, because the use-case in admin is to upload and then associate a file to a field.
@@ -843,6 +851,15 @@ header.phone:
   label: 'Your Phone Number'
 [/prism]
 
+[div class="table table-keycol"]
+| Attribute | Description                                       |
+| :-----    | :-----                                            |
+| `minlength` | minimum text length |
+| `maxlength`  | maximum text length  |
+| `validate.min` | same as minlength |
+| `validate.max`  | same as maxlength  |
+[/div]
+
 [div class="table"]
 | Common Attributes Allowed                      |
 | :-----                                         |
@@ -880,9 +897,8 @@ header.title:
   type: text
   autofocus: true
   label: PLUGIN_ADMIN.TITLE
-  validate:
-    min: 10
-    max: 255
+  minlength: 10
+  maxlength: 255
 [/prism]
 
 [div class="table table-keycol"]
@@ -890,8 +906,10 @@ header.title:
 | :-----    | :-----                                            |
 | `prepend` | prepend some text or HTML to the front of a field |
 | `append`  | append some text or HTML to the end of a field  |
-| `validate.min` | minimum text length |
-| `validate.max`  | maximum text length  |
+| `minlength` | minimum text length |
+| `maxlength`  | maximum text length  |
+| `validate.min` | same as minlength |
+| `validate.max`  | same as maxlength  |
 [/div]
 
 [div class="table"]
@@ -930,6 +948,8 @@ header.content:
   type: textarea
   autofocus: true
   label: PLUGIN_ADMIN.CONTENT
+  minlength: 10
+  maxlength: 255
 [/prism]
 
 [div class="table table-keycol"]
@@ -937,7 +957,13 @@ header.content:
 | :-----    | :-----                                                          |
 | `rows`    | Add a rows attribute with the value associated with this property |
 | `cols`    | Add a cols attribute with the value associated with this property |
+| `minlength` | minimum text length |
+| `maxlength`  | maximum text length  |
+| `validate.min` | same as minlength |
+| `validate.max`  | same as maxlength  |
+[/div]
 
+[div class="table"]
 | Common Attributes Allowed                      |
 | :-----                                         |
 | [autofocus](#common-fields-attributes)         |
@@ -957,7 +983,7 @@ header.content:
 | [validate.required](#common-fields-attributes) |
 | [validate.pattern](#common-fields-attributes)  |
 | [validate.message](#common-fields-attributes)  |
-
+[/div]
 ---
 
 ### Toggle Field
@@ -987,7 +1013,9 @@ summary.enabled:
 | :-----      | :-----                                                       |
 | `highlight` | The key of the option to highlight (set green when selected) |
 | `options`   | The list of key-value options                              |
+[/div]
 
+[div class="table"]
 | Common Attributes Allowed                      |
 | :-----                                         |
 | [default](#common-fields-attributes)           |
@@ -999,7 +1027,7 @@ summary.enabled:
 | [validate.required](#common-fields-attributes) |
 | [validate.type](#common-fields-attributes)     |
 | [disabled](#common-fields-attributes)          |
-
+[/div]
 ---
 
 ### Url Field
@@ -1012,6 +1040,15 @@ header.phone:
   type: url
   label: 'Your Phone Number'
 [/prism]
+
+[div class="table table-keycol"]
+| Attribute | Description                                       |
+| :-----    | :-----                                            |
+| `minlength` | minimum text length |
+| `maxlength`  | maximum text length  |
+| `validate.min` | same as minlength |
+| `validate.max`  | same as maxlength  |
+[/div]
 
 [div class="table"]
 | Common Attributes Allowed                      |

--- a/pages/06.forms/02.forms/02.fields-available/docs.md
+++ b/pages/06.forms/02.forms/02.fields-available/docs.md
@@ -880,6 +880,9 @@ header.title:
   type: text
   autofocus: true
   label: PLUGIN_ADMIN.TITLE
+  validate:
+    min: 10
+    max: 255
 [/prism]
 
 [div class="table table-keycol"]
@@ -887,6 +890,8 @@ header.title:
 | :-----    | :-----                                            |
 | `prepend` | prepend some text or HTML to the front of a field |
 | `append`  | append some text or HTML to the end of a field  |
+| `validate.min` | minimum text length |
+| `validate.max`  | maximum text length  |
 [/div]
 
 [div class="table"]


### PR DESCRIPTION
Note:
1. `minlength` and `maxlength` is also supported. Should we add that as well?
2. I've opened a PR for the textarea field to behave idential: https://github.com/getgrav/grav-plugin-form/pull/455 We should document that as well.