### PR TITLE
Add note the the "remember" option is not supported for checkboxes

### DIFF
--- a/pages/06.forms/02.forms/02.fields-available/docs.md
+++ b/pages/06.forms/02.forms/02.fields-available/docs.md
@@ -233,6 +233,8 @@ my_field:
 | [validate.message](#common-fields-attributes)  |
 [/div]
 
+!! NOTE: The checkboxes field does not support the `remember` process action.
+
 ---
 ### Conditional Field
 


### PR DESCRIPTION
This does not work because `setcookie()` does not support arrays and getting the cookie would also not work, as `value` is overwritten before:

This is executed before...
https://github.com/getgrav/grav-plugin-form/blob/4754239a60b4b2fa75e8162ea7185e02d3394a15/templates/forms/fields/checkboxes/checkboxes.html.twig#L4-L7

...this line, which has a `value ??` check.
https://github.com/getgrav/grav-plugin-form/blob/4754239a60b4b2fa75e8162ea7185e02d3394a15/templates/forms/default/field.html.twig#L21

I am not sure about the `toggleable` and `overridable` options, as I do not yet fully understand what they do. I assume that this is less important for checkboxes though.