### PR TITLE
List field item placement property

### DIFF
--- a/pages/06.forms/01.blueprints/01.fields-available/docs.md
+++ b/pages/06.forms/01.blueprints/01.fields-available/docs.md
@@ -523,7 +523,7 @@ header.fieldset:
 
 #### Icon of the fieldset
 
-You can use an icon to place in the header of the fieldset. The icon system used is [Fork Awesome](https://forkaweso.me). 
+You can use an icon to place in the header of the fieldset. The icon system used is [Fork Awesome](https://forkaweso.me).
 
 [div class="table table-keycol"]
 | Attribute     | Description                                                                                                |
@@ -549,7 +549,7 @@ You can use an icon to place in the header of the fieldset. The icon system used
 
 ![File Field](file_field_bp.gif)
 
-!! The `file` field is intended to be used by **configuration**, **theme**, and **plugins** blueprints, **NOT page blueprints**.  For pages, you should use the existing `pagemedia` field and then utilize the [filepicker](#filepicker-field) field to select the files. 
+!! The `file` field is intended to be used by **configuration**, **theme**, and **plugins** blueprints, **NOT page blueprints**.  For pages, you should use the existing `pagemedia` field and then utilize the [filepicker](#filepicker-field) field to select the files.
 
 !! The `file` field does not currently work as expected in a list field. Use a single `pagemedia` field separate from the list with one or more `filepicker` fields in the list.
 
@@ -765,7 +765,8 @@ Accessing and displaying the data of a `list` field is done with a simple twig f
 | `style`     | Can be set to `vertical` to conserve horizontal space    |
 | `btnLabel`  | The "add new item" label text                            |
 | `sort`      | Boolean. If negative, disables the ability to sort items |
-| `controls`  | Decides where the "Add Item" button will be placed. Can be set to `[top|bottom|both]` defaults to `bottom`.  |
+| `controls`  | Decides where the "Add Item" button will be placed. Can be set to `[top|bottom|both]`. Defaults to `bottom`.  |
+| `placement` | Decides where the added item will be placed. Can be set to `[top|bottom|position]`. Defaults to `bottom`. If `placement` value is `top` or `bottom`, both buttons add item to top or bottom respectively. If `placement` value is `position`, item is added depending on a clicked button position - if top button is clicked, item will be added to top and if bottom button - to bottom.  |
 | `min`       | Minimum number of items allowed in the list.             |
 | `max`       | Maximum number of items allowed in the list. 'Add item' button won't function past this number |
 [/div]

--- a/pages/06.forms/01.blueprints/01.fields-available/docs.md
+++ b/pages/06.forms/01.blueprints/01.fields-available/docs.md
@@ -523,7 +523,7 @@ header.fieldset:
 
 #### Icon of the fieldset
 
-You can use an icon to place in the header of the fieldset. The icon system used is [Fork Awesome](https://forkaweso.me). 
+You can use an icon to place in the header of the fieldset. The icon system used is [Fork Awesome](https://forkaweso.me).
 
 [div class="table table-keycol"]
 | Attribute     | Description                                                                                                |

--- a/pages/06.forms/01.blueprints/01.fields-available/docs.md
+++ b/pages/06.forms/01.blueprints/01.fields-available/docs.md
@@ -501,7 +501,7 @@ header.fieldset:
 
 !Fieldsets have to be saved in the frontmatter too, with `header.`, in order for their sub-field states to be correctly remembered!
 
-!! **Known issue :** if fields in a fieldset use a `toggleable:`, their state won't be memorized if the fieldset named isn't prefixed with `header.`. Here's an example of a valid structure with a modification of the *pagination* option :
+!! **Known issue :** if fields in a fieldset use a `toggleable:`, their state won't be memorized if the fieldset named isn't prefixed with `header.`. Here's an example of a valid structure with a modification of the *pagination* option : 
 
 [prism classes="language-yaml line-numbers"]
 header.fieldset:
@@ -523,7 +523,7 @@ header.fieldset:
 
 #### Icon of the fieldset
 
-You can use an icon to place in the header of the fieldset. The icon system used is [Fork Awesome](https://forkaweso.me).
+You can use an icon to place in the header of the fieldset. The icon system used is [Fork Awesome](https://forkaweso.me). 
 
 [div class="table table-keycol"]
 | Attribute     | Description                                                                                                |
@@ -549,7 +549,7 @@ You can use an icon to place in the header of the fieldset. The icon system used
 
 ![File Field](file_field_bp.gif)
 
-!! The `file` field is intended to be used by **configuration**, **theme**, and **plugins** blueprints, **NOT page blueprints**.  For pages, you should use the existing `pagemedia` field and then utilize the [filepicker](#filepicker-field) field to select the files.
+!! The `file` field is intended to be used by **configuration**, **theme**, and **plugins** blueprints, **NOT page blueprints**.  For pages, you should use the existing `pagemedia` field and then utilize the [filepicker](#filepicker-field) field to select the files. 
 
 !! The `file` field does not currently work as expected in a list field. Use a single `pagemedia` field separate from the list with one or more `filepicker` fields in the list.
 

--- a/pages/06.forms/01.blueprints/01.fields-available/docs.md
+++ b/pages/06.forms/01.blueprints/01.fields-available/docs.md
@@ -501,7 +501,7 @@ header.fieldset:
 
 !Fieldsets have to be saved in the frontmatter too, with `header.`, in order for their sub-field states to be correctly remembered!
 
-!! **Known issue :** if fields in a fieldset use a `toggleable:`, their state won't be memorized if the fieldset named isn't prefixed with `header.`. Here's an example of a valid structure with a modification of the *pagination* option : 
+!! **Known issue :** if fields in a fieldset use a `toggleable:`, their state won't be memorized if the fieldset named isn't prefixed with `header.`. Here's an example of a valid structure with a modification of the *pagination* option :
 
 [prism classes="language-yaml line-numbers"]
 header.fieldset:
@@ -523,7 +523,7 @@ header.fieldset:
 
 #### Icon of the fieldset
 
-You can use an icon to place in the header of the fieldset. The icon system used is [Fork Awesome](https://forkaweso.me).
+You can use an icon to place in the header of the fieldset. The icon system used is [Fork Awesome](https://forkaweso.me). 
 
 [div class="table table-keycol"]
 | Attribute     | Description                                                                                                |


### PR DESCRIPTION
This adds description for `placement` property for List field.
It was newly added to Admin and Flex Object plugins. PRs are [here for Admin](https://github.com/getgrav/grav-plugin-admin/pull/2055) and [here for Flex](https://github.com/trilbymedia/grav-plugin-flex-objects/pull/105)

Probably shouldn't be merged before the mentioned PRs are merged