### PR TITLE
remove `validate.required` for file field, as it is not supported

### DIFF
--- a/pages/06.forms/02.forms/02.fields-available/docs.md
+++ b/pages/06.forms/02.forms/02.fields-available/docs.md
@@ -451,7 +451,6 @@ my_files:
 | [label](#common-fields-attributes)             |
 | [name](#common-fields-attributes)              |
 | [outerclasses](#common-fields-attributes)      |
-| [validate.required](#common-fields-attributes) |
 [/div]
 
 By default, in Admin the `file` field will overwrite an uploaded file that has the same name of a newer one, contained in the same folder you want to upload it, unless you set `avoid_overwriting` to `true` in the field definition.


### PR DESCRIPTION
As stated here https://github.com/getgrav/grav-plugin-form/issues/499 the form field of type `file` does not support the option `validate: required`.