### PR TITLE
Fix unopened parenthesis in Scheduler code example

### DIFF
--- a/pages/08.advanced/06.scheduler/docs.16.md
+++ b/pages/08.advanced/06.scheduler/docs.16.md
@@ -181,7 +181,7 @@ public function onSchedulerInitialized(Event $e): void
 {
     $config = $this->config();
 
-    if (!empty($config['scheduled_index']['enabled']))) {
+    if (!empty($config['scheduled_index']['enabled'])) {
         $scheduler = $e['scheduler'];
         $at = $config['scheduled_index']['at'] ?? '* * * * *';
         $logs = $config['scheduled_index']['logs'] ?? '';


### PR DESCRIPTION
Removed un-needed closing parenthesis at [L184](https://github.com/getgrav/grav-learn/blame/develop/pages/08.advanced/06.scheduler/docs.16.md#L184).