### PR TITLE
Update docs.md

### DIFF
--- a/pages/06.forms/01.blueprints/04.example-page-blueprint/docs.md
+++ b/pages/06.forms/01.blueprints/04.example-page-blueprint/docs.md
@@ -186,7 +186,7 @@ In order for the Admin Plugin to pick up the blueprints, and thus show the new P
 
 #### In the User Blueprints folder
 
-Put them in `user/blueprints/`. This is a good place to put them when you simply want your blueprints to be present in your site.
+Put them in `user/blueprints/pages/`. This is a good place to put them when you simply want your blueprints to be present in your site.
 
 #### In the Theme
 


### PR DESCRIPTION
Hello,
I just noticed that a blueprint for a page (that is not to be included in the theme), in order to be considered in page-rendering, needs to be placed in a subfolder of user/blueprints named 'pages'. I.e. it needs to be in the folder user/blueprints/pages. If it is just in the folder user/blueprints, as the document text suggests, it seems not to be taken into account.