### PR TITLE
Provide more precise description of how absolute_url Twig filter works

### DIFF
--- a/pages/03.themes/04.twig-tags-filters-functions/02.filters/docs.md
+++ b/pages/03.themes/04.twig-tags-filters-functions/02.filters/docs.md
@@ -15,7 +15,7 @@ Twig filters are applied to Twig variables by using the `|` character followed b
 
 ### `absolute_url`
 
-Take a relative path and convert it to an absolute URL format including hostname
+Takes an HTML snippet containing a `src` or `href` attribute which uses a relative path. Converts the path string to an absolute URL format including hostname.
 
 `'<img src="/some/path/to/image.jpg" />'|absolute_url` <i class="fa fa-long-arrow-right"></i> `{{ '<img src="/some/path/to/image.jpg" />'|absolute_url|raw }}`
 


### PR DESCRIPTION
The description given before is confusing because it suggests the filter only requires the path.