### PR TITLE
Update links in docs

### DIFF
--- a/pages/01.basics/01.what-is-grav/docs.md
+++ b/pages/01.basics/01.what-is-grav/docs.md
@@ -15,14 +15,14 @@ The underlying architecture of Grav is built using well established and _best-in
 * [YAML](https://yaml.org): for simple configuration
 * [Parsedown](https://parsedown.org/): for fast Markdown and Markdown Extra support
 * [Doctrine Cache](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/caching.html): for performance
-* [Pimple Dependency Injection Container](https://pimple.symfony.com/): for extensibility and maintainability
+* [Pimple Dependency Injection Container](https://github.com/silexphp/Pimple): for extensibility and maintainability
 * [Symfony Event Dispatcher](https://symfony.com/doc/current/components/event_dispatcher.html): for plugin event handling
 * [Symfony Console](https://symfony.com/doc/current/components/console.html): for CLI interface
 * [Gregwar Image Library](https://github.com/Gregwar/Image): for dynamic image manipulation
 
 ## Grav's Place in the Universe
 
-There are many powerful open source CMS solutions for building complex websites.  Some of the more commonly used ones are [Joomla](https://joomla.org), [WordPress](https://wordpress.org), and [Drupal](https://drupal.org). The downside of these platforms is that they have a steep learning curve associated with them. This requires a significant amount of your time - and this may be the time that you do not have.
+There are many powerful open source CMS solutions for building complex websites.  Some of the more commonly used ones are [Joomla](https://wwwjoomla.org), [WordPress](https://wordpress.org), and [Drupal](https://www.drupal.org). The downside of these platforms is that they have a steep learning curve associated with them. This requires a significant amount of your time - and this may be the time that you do not have.
 
 These platforms provide a wealth of features and functionality that you can extend with a wide variety of open source and proprietary plug-ins and themes.  These extensions and themes are themselves often feature-packed, requiring more knowledge and time on the part of the developer yet.
 

--- a/pages/01.basics/01.what-is-grav/docs.md
+++ b/pages/01.basics/01.what-is-grav/docs.md
@@ -22,7 +22,7 @@ The underlying architecture of Grav is built using well established and _best-in
 
 ## Grav's Place in the Universe
 
-There are many powerful open source CMS solutions for building complex websites.  Some of the more commonly used ones are [Joomla](https://wwwjoomla.org), [WordPress](https://wordpress.org), and [Drupal](https://www.drupal.org). The downside of these platforms is that they have a steep learning curve associated with them. This requires a significant amount of your time - and this may be the time that you do not have.
+There are many powerful open source CMS solutions for building complex websites.  Some of the more commonly used ones are [Joomla](https://www.joomla.org), [WordPress](https://wordpress.org), and [Drupal](https://www.drupal.org). The downside of these platforms is that they have a steep learning curve associated with them. This requires a significant amount of your time - and this may be the time that you do not have.
 
 These platforms provide a wealth of features and functionality that you can extend with a wide variety of open source and proprietary plug-ins and themes.  These extensions and themes are themselves often feature-packed, requiring more knowledge and time on the part of the developer yet.
 


### PR DESCRIPTION
- update 301/302 redirects for Drupal and Joomla
- update link for Pimple dependency injection container (which refuses connection on port 443, but does redirect to the project GitHub repo correctly from port 80)