### PR TITLE
Add important notice about rerouting paths containing regex characters

### DIFF
--- a/pages/02.content/10.routing/docs.md
+++ b/pages/02.content/10.routing/docs.md
@@ -45,6 +45,7 @@ These are handled via the [Site Configuration](../../basics/grav-configuration#s
 
 !! All redirect rules apply on the slug-path beginning after the language part (if you use multi-language pages)
 
+!!!! You must escape certain characters in any routes that you want to match. This is especially important to know if you are migrating an old site that used links containing legacy file extensions (e.g. `.php`) or URL parameters (`?foo=bar`). In these examples, the period and question mark **must be escaped** like `/index\.php\?foo=bar: '/new/location'`.
 
 ### Route Aliases
 


### PR DESCRIPTION
Found this [important info snippet in an issue comment explaining why some legacy redirects didn't work](https://github.com/getgrav/grav/issues/1983#issuecomment-382528689). IMO it's a detail that needs to be documented in a more obvious place.