### PR TITLE
Fix select field validation when `multiple` is set to true

### DIFF
--- a/pages/06.forms/02.forms/02.fields-available/docs.md
+++ b/pages/06.forms/02.forms/02.fields-available/docs.md
@@ -733,7 +733,13 @@ pages.order.by:
 | `multiple` | Allow the form to accept multiple values.           |
 [/div]
 
-If you set `multiple` to true, you need to add `validate.type: array`. Otherwise the array of selected values will not be saved correctly.
+If you set `multiple` to true, you need to add 
+```
+pages.order.by:
+  validate:
+    type: array
+```
+Otherwise the array of selected values will not be saved correctly.
 
 [div class="table"]
 | Common Attributes Allowed                      |


### PR DESCRIPTION
If `validate.type: array` is on a single line, validation always fails for a multiple select, resulting in no data being saved.

Breaking up the validate and type onto separate lines fixes this issue.