### PR TITLE
Add flex-objects results in a new page

### DIFF
--- a/pages/08.advanced/01.flex/03.custom-types/01.blueprint/docs.17.md
+++ b/pages/08.advanced/01.flex/03.custom-types/01.blueprint/docs.17.md
@@ -609,3 +609,6 @@ blueprints:
 ! **TIP:** These configuration options can be modified in **[Configuration](/advanced/flex/administration/configuration)** section of the **[Flex Directory Administration](/advanced/flex/administration)**.
 
 !!! **NOTE:** Currently the only used configuration options are inside the cache section. For your custom settings, you need to add logic to use them by yourself.
+
+!!! **NOTE:** A flex object will be added to as extra page and is accessable and included in xml sitemap. Add `header.published` in your blueprint fields to avoid generating extra pages.
+


### PR DESCRIPTION
Workaround for me is 

```yaml
    header.published:
      type: toggle
      label: Published (as extra site)
      highlight: 0
      options:
        1: PLUGIN_ADMIN.YES
        0: PLUGIN_ADMIN.NO
      default: 0
      validate:
        type: bool
```

Found no way to hide it or apply it without an extra field or patch