### PR TITLE
Add proper page header names for field Elements

### DIFF
--- a/pages/06.forms/01.blueprints/01.fields-available/docs.md
+++ b/pages/06.forms/01.blueprints/01.fields-available/docs.md
@@ -482,7 +482,7 @@ This field is only organizational and allows grouping items within a named group
 Example:
 
 [prism classes="language-yaml line-numbers"]
-header.elements-demo:
+header.elements-demo.type:
   type: elements
   label: 'Elements Demo'
   size: small
@@ -495,7 +495,7 @@ header.elements-demo:
     gelato:
       type: element
       fields:
-        .items:
+        header.elements-demo.gelato:
           type: array
           default:
             pistacchio: Pistacchio
@@ -505,14 +505,14 @@ header.elements-demo:
     color:
       type: element
       fields:
-        .items:
+        header.elements-demo.color:
           type: textarea
           rows: 10
           default: Color (American English) or colour (Commonwealth English) is the visual perceptual property corresponding in humans to the categories called blue, green, red, etc. Color derives from the spectrum of light (distribution of light power versus wavelength) interacting in the eye with the spectral sensitivities of the light receptors. Color categories and physical specifications of color are also associated with objects or materials based on their physical properties such as light absorption, reflection, or emission spectra. By defining a color space colors can be identified numerically by their coordinates.
     planets:
       type: element
       fields:
-        .items:
+        header.elements-demo.planets:
           type: text
           placeholder: What are your favorite planets?
           markdown: true


### PR DESCRIPTION
See issue [Elements field not saving data of element #552](https://github.com/getgrav/grav-plugin-form/issues/552)

The sample given for field Elements contains incorrect field names. Since sample started as a Page blueprint, I've updated all fields with a proper header prefix.