### PR TITLE
from `master` to `main`

### DIFF
--- a/pages/08.advanced/09.grav-development/docs.md
+++ b/pages/08.advanced/09.grav-development/docs.md
@@ -157,7 +157,7 @@ As is the way of things these days, GitHub is going to be your best friend when 
 
 Clone all the repositories you plan to work with into a single `Projects` or `Development` folder on your computer. This will allow our provided tools to find the repositories they need.
 
-!! We use the [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/) branching model for all our Grav development.  The core concept of the GitFlow methodology is that development happens in the `develop` branch, but new features and functionality are created in separate `feature` branches that are merged into `develop` when complete.  Releases merge `develop` into `master`, and you can apply `hotfix` branches as needed during the release process. Most modern git clients support this. However, we recommend [Atlassian SourceTree](https://www.atlassian.com/software/sourcetree/overview) as it's free, cross-platform, and easy to use.
+!! We use the [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/) branching model for all our Grav development.  The core concept of the GitFlow methodology is that development happens in the `develop` branch, but new features and functionality are created in separate `feature` branches that are merged into `develop` when complete.  Releases merge `develop` into `main`, and you can apply `hotfix` branches as needed during the release process. Most modern git clients support this. However, we recommend [Atlassian SourceTree](https://www.atlassian.com/software/sourcetree/overview) as it's free, cross-platform, and easy to use.
 
 Grav also has some dependencies (dictated by the `.dependencies` file) which include the **Error** and **Problems** plugins, as well as the **Antimatter** theme.  You can follow these instructions to clone these bits on your own computer.
 
@@ -271,7 +271,7 @@ People move on, and user-generated content like plugins and themes may become ab
 
 5. Prepare your forked repository with a new release.
 
-6. Add a note to the README that this repository is the new master and link back to the old repository.
+6. Add a note to the README that this repository is the new `main` and link back to the old repository.
 
 7. Reply to the issue, giving the maintainers the new URL for the plugin.
 


### PR DESCRIPTION
We should also rename the default branch of our own repositories from `master` to `main`.