### PR TITLE
Add docs about field attributes and datasets

### DIFF
--- a/pages/06.forms/02.forms/02.fields-available/docs.md
+++ b/pages/06.forms/02.forms/02.fields-available/docs.md
@@ -39,6 +39,23 @@ This list provides a common ground so there's no need to repeat the description 
 | `validate.message`  | sets the message shown if the validation fails                                                                                                                                                                 |
 [/div]
 
+To add custom attributes, you can use:
+```
+attributes:
+  key: value
+```
+
+To add custom data-* values, you can use:
+```
+datasets:
+  key: value
+```
+
+The above shown `attributes` and `datasets` definitions lead to the following field definition:
+```
+<input name="data[name]" value="" type="text" class="form-input " key="value" data-key="value">
+```
+
 !!! NOTE: You can set positive values in multiple ways: `'on'`, `true`, `1`. Other values are interpreted as negative.
 
 ---


### PR DESCRIPTION
The possibility to add custom attributes and custom data-* attributes has not yet been documented although provided by */form/templates/forms/default/default.html.twig* [lines 139-157](https://github.com/getgrav/grav-plugin-form/blob/2b6bb888261aeb14780de2f9db12068ab7bb0cea/templates/forms/default/field.html.twig#L139-L156)