### PR TITLE
Update docs.md

### DIFF
--- a/pages/06.forms/02.forms/03.example-form/docs.md
+++ b/pages/06.forms/02.forms/03.example-form/docs.md
@@ -22,7 +22,7 @@ The Sora Article skeleton has a form page ready to see while reading this tutori
 
 You can put a form inside any page of your site. All you need to do is rename the page markdown file to `form.md`, or add a [template](../../../content/headers#template) header in the page frontmatter, to make it use the `form` template.
 
-!! Your theme's `base.html.twig` template must implement the `{% block content %}` tag in order for the **Grav Form Plugin** to render your inputs on the page.
+!! Your page's template, or page's parent template, must implement the `{% block content %}` tag in order for the **Grav Form Plugin** to render your inputs on the page.
 
 The form fields and processing instructions are defined in the YAML frontmatter of the page, so just open the page markdown file with your favorite editor, and put the following code in it:
 


### PR DESCRIPTION
My previous edit was incorrect. In fact, {% block content %} just needs to be implemented somewhere, not necessarily in the base.html.twig. In the case of Quark it's used in default.html.twig. It only matters that {% block content %} is found somewhere in the template inheritance hierarchy for a given page.