### PR TITLE
Update twig documentation links

### DIFF
--- a/pages/02.content/02.headers/docs.md
+++ b/pages/02.content/02.headers/docs.md
@@ -434,7 +434,7 @@ You could then access them from Twig:
 </section>
 [/prism]
 
-If the variable name [contains a special character like a dash](https://github.com/getgrav/grav/issues/1957#issuecomment-723236844) you should use [twigs attribute function](https://twig.symfony.com/doc/2.x/functions/attribute.html):
+If the variable name [contains a special character like a dash](https://github.com/getgrav/grav/issues/1957#issuecomment-723236844) you should use [twigs attribute function](https://twig.symfony.com/doc/1.x/functions/attribute.html):
 
 [prism classes="language-twig"] attribute(page.header, 'plugin-name').active [/prism]
 

--- a/pages/03.themes/03.twig-primer/docs.md
+++ b/pages/03.themes/03.twig-primer/docs.md
@@ -56,7 +56,7 @@ A template is first loaded, then passed through the **lexer** where its source c
 
 Once this is done, the compiler turns this into PHP code that can then be evaluated and displayed to the user.
 
-Twig can also be extended to add additional tags, filters, tests, operators, global variables, and functions. More information about extending Twig can be found in its [official documentation](http://twig.sensiolabs.org/doc/advanced.html).
+Twig can also be extended to add additional tags, filters, tests, operators, global variables, and functions. More information about extending Twig can be found in its [official documentation](https://twig.symfony.com/doc/1.x/advanced.html).
 
 ## Twig Syntax
 

--- a/pages/03.themes/04.twig-tags-filters-functions/docs.md
+++ b/pages/03.themes/04.twig-tags-filters-functions/docs.md
@@ -9,7 +9,7 @@ routes:
     - '/themes/twig-filters-functions'
 ---
 
-Although Twig already provides an extensive list of [filters, functions, and tags](http://twig.sensiolabs.org/documentation), Grav also provides a selection of useful additions to make the process of theming easier.
+Although Twig already provides an extensive list of [filters, functions, and tags](https://twig.symfony.com/doc/1.x/#reference), Grav also provides a selection of useful additions to make the process of theming easier.
 
 !! For information about developing your own custom Twig Filters, check out the [Custom Twig Filter/Function](/cookbook/twig-recipes/#custom-twig-filter-function) example in the **Twig Recipes** section of the **Cookbook** chapter.
 

--- a/pages/03.themes/06.theme-vars/docs.md
+++ b/pages/03.themes/06.theme-vars/docs.md
@@ -6,7 +6,7 @@ taxonomy:
     category: docs
 ---
 
-When you are designing a theme, Grav gives you access to all sorts of objects and variables from within your Twig templates.  The Twig templating framework provides powerful ways to read and manipulate these objects and variables.  This is [fully explained in their own documentation](http://twig.sensiolabs.org/doc/templates.html) as well as [summarized succinctly in our own documentation](../twig-primer).
+When you are designing a theme, Grav gives you access to all sorts of objects and variables from within your Twig templates.  The Twig templating framework provides powerful ways to read and manipulate these objects and variables.  This is [fully explained in their own documentation](https://twig.symfony.com/doc/1.x/templates.html) as well as [summarized succinctly in our own documentation](../twig-primer).
 
 !!!! In Twig, you can call methods that take no parameters by just calling the method name, and omitting the parentheses `()`.  If you need to pass parameters, you also need to provide those after the method name.  `page.content` is equivalent to `page.content()`
 

--- a/pages/03.themes/07.asset-manager/docs.15.md
+++ b/pages/03.themes/07.asset-manager/docs.15.md
@@ -67,7 +67,7 @@ An example of how you can add CSS files in your theme can be found in the defaul
 
 The `block` twig tag just defines a region that can be replaced or appended to in templates that extend the one. Within the block, you will see a number of `do assets.addCss()` calls.
 
-The `{% do %}` tag is actually [one built in to Twig](http://twig.sensiolabs.org/doc/tags/do.html) itself, and it lets you manipulate variables without generating any output.
+The `{% do %}` tag is actually [one built in to Twig](https://twig.symfony.com/doc/1.x/tags/do.html) itself, and it lets you manipulate variables without generating any output.
 
 The `addCss()` method adds CSS assets to the Asset Manager. If you specify a second numeric parameter, that sets the priority of the stylesheet. In this case we want `grids-min.css` to be first as it has the highest priority value.  You will notice the use of a **PHP stream wrapper** `theme://` to provide an easy way for Grav to determine the current theme's relative path.
 

--- a/pages/03.themes/07.asset-manager/docs.16.md
+++ b/pages/03.themes/07.asset-manager/docs.16.md
@@ -178,7 +178,7 @@ An example of how you can add CSS files in your theme can be found in the defaul
 
 The `block stylesheets` twig tag just defines a region that can be replaced or appended to in templates that extend the one. Within the block, you will see a number of `do assets.addCss()` calls.
 
-The `{% do %}` tag is actually [one built in to Twig](http://twig.sensiolabs.org/doc/tags/do.html) itself, and it lets you manipulate variables without generating any output.
+The `{% do %}` tag is actually [one built in to Twig](https://twig.symfony.com/doc/1.x/tags/do.html) itself, and it lets you manipulate variables without generating any output.
 
 The `addCss()` method adds CSS assets to the Asset Manager. If you specify a second numeric parameter, that sets the priority of the stylesheet. If you do not specify a priority, the priority that the assets are added will dictate the order they are rendered.  You will notice the use of a **PHP stream wrapper** `theme://` to provide an easy way for Grav to determine the current theme's relative path.
 

--- a/pages/04.plugins/04.event-hooks/docs.md
+++ b/pages/04.plugins/04.event-hooks/docs.md
@@ -215,7 +215,7 @@ The Twig templating engine is now initialized at this point.
 <a name="onTwigExtensions"></a>
 #### onTwigExtensions
 
-The core Twig extensions have been loaded, but if you need to add [your own Twig extension](https://twig.symfony.com/doc/3.x/advanced.html#id2), you can do so with this event hook.
+The core Twig extensions have been loaded, but if you need to add [your own Twig extension](https://twig.symfony.com/doc/1.x/advanced.html#creating-an-extension), you can do so with this event hook.
 
 <a name="onTwigPageVariables"></a>
 #### onTwigPageVariables

--- a/pages/13.security/04.developers/docs.md
+++ b/pages/13.security/04.developers/docs.md
@@ -10,7 +10,7 @@ When creating a plugin or theme for Grav, it is not only important to follow bes
 
 These are some recommendations for how to best create a secure and trustworthy extension to Grav, and should be considered essential knowledge for any theme- or plugin-author 
 
-- When writing Twig-templates that output user-submitted information, always [escape the input](https://twig.sensiolabs.org/doc/2.x/filters/escape.html), this also includes [assets](https://twig.sensiolabs.org/doc/2.x/filters/raw.html).
+- When writing Twig-templates that output user-submitted information, always [escape the input](https://twig.symfony.com/doc/1.x/filters/escape.html), this also includes [assets](https://twig.symfony.com/doc/1.x/filters/raw.html).
 - PHP-code should [sanitize](https://php.net/manual/en/filter.filters.sanitize.php) input and output.
 - Blueprints should prefer preset options: When possible, give the user a set of choices rather than raw input.
 - Be aware of how memory and processor-usage affect the extension, and avoid using system resources unjustifiably.


### PR DESCRIPTION
I went with the 1.x docs for twig since https://github.com/getgrav/grav/blob/e9f28ab824bb66534119dc70703c09959922dcdb/composer.json#L33 has a 1.x version, and https://github.com/getgrav/grav-learn/blob/2fad122466373a7de1e8ff9e84be677875a591ad/pages/03.themes/03.twig-primer/docs.md?plain=1#L142 also links to the 1.x docs.

Edit: found a second and then a third issue, decided to do a mass search and correct all that I could.