### PR TITLE
Documented `value_type` attribute for Array fields (#1043)

### DIFF
--- a/pages/06.forms/01.blueprints/01.fields-available/docs.md
+++ b/pages/06.forms/01.blueprints/01.fields-available/docs.md
@@ -250,6 +250,7 @@ metadata:
 | `placeholder_key`   |             |
 | `placeholder_value` |             |
 | `value_only`        | Do not require or store array keys, just store a simple array of values. |
+| `value_type`        | Set to `textarea` to display a [textarea field](/forms/forms/fields-available#textarea-field) for entering array values rather than the smaller [text field](/forms/forms/fields-available#text-field). |
 [/div]
 
 [div class="table table-keycol"]


### PR DESCRIPTION
The Array field introduced in the Form plugin [has an undocumented property `value_type`](https://github.com/getgrav/grav-plugin-form/blob/develop/templates/forms/fields/array/array.html.twig#L21) which can be set to `value_type: textarea` to change the value entry element from an `<input>` to a `<textarea>`.

![image](https://user-images.githubusercontent.com/8947634/196750301-72d78dba-65b1-44a0-a01f-16d5bb46f976.png)
![image](https://user-images.githubusercontent.com/8947634/196750284-ae6b25c4-5f51-40db-a2f9-0dd532fef8ac.png)

This pull-request documents this behaviour in the appropriate blueprint fields reference page.