### PR TITLE
Update doc example to only return published pages instead of all

### DIFF
--- a/pages/10.cookbook/02.twig-recipes/docs.md
+++ b/pages/10.cookbook/02.twig-recipes/docs.md
@@ -21,7 +21,7 @@ Simply find the `/blog` page, obtain it's children, order them by date in a desc
 
 [prism classes="language-twig line-numbers"]
 <ul>
-{% for post in page.find('/blog').children.order('date', 'desc').slice(0, 5) %}
+{% for post in page.find('/blog').children.published.order('date', 'desc').slice(0, 5) %}
     <li class="recent-posts">
         <strong><a href="{{ post.url }}">{{ post.title }}</a></strong>
     </li>


### PR DESCRIPTION
Adding the `.published` option here ensures that only published pages will be returned in this list.  Without this all pages, whether they are published on or not would show up.