### PR TITLE
Fix `Section` blueprint form field, close 1053

### DIFF
--- a/pages/06.forms/01.blueprints/01.fields-available/docs.md
+++ b/pages/06.forms/01.blueprints/01.fields-available/docs.md
@@ -952,7 +952,6 @@ content:
 | `underline`   | Add an underline after the title                               |
 | `text`        | A text to show beneath                                         |
 | `security`    | An array of credentials a user needs to visualize this section |
-| `title_level` | Set a custom headline tag. Default: `h3`                       |
 [/div]
 
 


### PR DESCRIPTION
Removes the erroneous reference to `title_level` attribute in blueprint form fields index for `Section` field. See: https://github.com/getgrav/grav-learn/issues/1053