### PR TITLE
Correction to preg_match() PHP Manual url

### DIFF
--- a/pages/03.themes/04.twig-tags-filters-functions/03.functions/docs.md
+++ b/pages/03.themes/04.twig-tags-filters-functions/03.functions/docs.md
@@ -338,7 +338,7 @@ A helpful wrapper for the PHP [preg_replace()](https://php.net/manual/en/functio
 [version=17]
 ### `regex_match`
 
-A helpful wrapper for the PHP [preg_match()](https://php.net/manual/en/function.preg-math.php) method, you can perform complex regular expression match on text via this filter:
+A helpful wrapper for the PHP [preg_match()](https://php.net/manual/en/function.preg-match.php) method, you can perform complex regular expression match on text via this filter:
 
 {% verbatim %}
 `regex_match('http://www.php.net/index.html', '@^(?:http://)?([^/]+)@i')`


### PR DESCRIPTION
Minor correction to external link.

PHP Manual link was: https://php.net/manual/en/function.preg-math.php

Should be: https://php.net/manual/en/function.preg-match.php