### PR TITLE
Added note to `header_var` which has been deprecated and its logic has changed.

### DIFF
--- a/pages/03.themes/04.twig-tags-filters-functions/03.functions/docs.md
+++ b/pages/03.themes/04.twig-tags-filters-functions/03.functions/docs.md
@@ -167,8 +167,16 @@ Takes a Github Gist ID and creates appropriate Gist embed code
 `gist('bc448ff158df4bc56217')` <i class="fa fa-long-arrow-right"></i> **{{ gist('bc448ff158df4bc56217')|e }}**
 
 ### `header_var`
+`header_var($variable, $pages = null)`
 
-Helper function. Returns `page.header.<variable>`.
+Returns `page.header.<variable>`.
+
+! **NOTE:** Deprecated since Grav 1.7. `theme_var` should be used.
+
+! The logic of finding the variable has changed, which might lead to unexptected results:
+! - If an array of lookup pages is provided as second parameter, only the first page will be used.
+! - If `<variable>` is not defined in het header of the page, Grav will search for the variable in the tree of parents of the page.
+! - If still not found, Grav will search for the variable in the config file of the theme
 
 Given frontmatter of
 ```
@@ -400,12 +408,15 @@ example:
 
 [version=16,17]
 ### `theme_var`
+`theme_var($variable, $default = null, $page = null)`
 
-Get a theme variable from the page header if it exists, else use the theme config:
+Get a theme variable from the page's header, or, if not found, from its parent(s), the theme's config file, or the default value if provided:
 
 `theme_var('grid-size')`
 
-This will first try `page.header.grid-size`, if that is not set, it will try `theme.grid-size` from the theme configuration file.  it can optionally take a default:
+This will first try `page.header.grid-size`, if not set, it will traverse the tree of parents. If still not found, it will try `theme.grid-size` from the theme's configuration file.
+
+It can optionally take a default value as fallback:
 
 `theme_var('grid-size', 1024)`
 [/version]


### PR DESCRIPTION
If I understand correctly, with the advent of Grav 1.7, `header_var` has been deprecated in favour of `theme_var`. Also its logic has been changed by using `theme_var` under the hood.

- I've added a note to `header_var` to let people know about these changes.
- I've also added a bit more explanation to `theme_var`.

Maybe Quark should also be changed. I notice that people tend to reused code from poster theme Quark, which still uses `header_var` with an array of pages as parameter.