### PR TITLE
Document option to choose destination path relative to the current page

### DIFF
--- a/pages/06.forms/01.blueprints/06.how-to-add-file-upload/docs.md
+++ b/pages/06.forms/01.blueprints/06.how-to-add-file-upload/docs.md
@@ -57,7 +57,7 @@ Like a regular HTML5 file field, when the `multiple` option is enabled, it allow
 destination: 'self@' # [<path> | <stream> | self@ | page@:<path>]
 ```
 
-Destination is the location where uploaded files should be stored. This can be either a regular `path` (relative to the root of Grav), a `stream` (such as `theme://images`), `self@` or the special  `page@:` prefix.
+Destination is the location where uploaded files should be stored. This can be either a regular `path` (relative to the root of Grav), a `stream` (such as `theme://images`), `self@` or the special  `page@:` prefix. You can also reference a subfolder relative to the current page with `self@/path`. 
 
 !! `self@` is not allowed outside the Pages or Flex Objects scope, an error will be thrown. If you use a file field outside a Page or Flex Object, you should always change the `destination` setting.
 


### PR DESCRIPTION
This was not at all obvious to me, and to find it I had to dig down into the code, where [it is already documented](https://github.com/getgrav/grav/blob/345086538caee1b4607a34b1d4429d08525e237e/system/src/Grav/Common/Utils.php#L1625). I tested it and it does seem to work.