### PR TITLE
Update blueprint config examples

### DIFF
--- a/pages/06.forms/01.blueprints/05.example-config-blueprints/docs.md
+++ b/pages/06.forms/01.blueprints/05.example-config-blueprints/docs.md
@@ -10,7 +10,7 @@ To make those options configurable via Admin panel, add some fields to `user/blu
 
 
 [prism classes="language-yaml line-numbers"]
-@extends:
+extends@:
     '@parent'
 
 form:
@@ -28,7 +28,7 @@ Will add the 'My Field' input type, appending it to the Content section of the S
 You can add entire new sections too, for example:
 
 [prism classes="language-yaml line-numbers"]
-@extends:
+extends@:
     '@parent'
 
 form:


### PR DESCRIPTION
The version on the site throws:
RuntimeException (500)
Cannot load blueprint config/site: Failed to read site.yaml: The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 1 (near "@extends:").