### PR TITLE
Add gzip compression for javascript in nginx config

### DIFF
--- a/pages/09.webservers-hosting/00.servers/01.nginx/docs.md
+++ b/pages/09.webservers-hosting/00.servers/01.nginx/docs.md
@@ -104,6 +104,7 @@ http {
         image/x-icon
         text/cache-manifest
         text/css
+        text/javascript
         text/plain
         text/vcard
         text/vnd.rim.location.xloc


### PR DESCRIPTION
The recommended `mime.types` file from h5bp causes javascript to be served as `text/javascript`, which is good. However, with the suggested `nginx.conf`, javascript won't be compressed because `text/javascript` isn't listed under `gzip_types`.