### PR TITLE
Update docs.md

### DIFF
--- a/pages/11.troubleshooting/05.invalid-security-token/docs.md
+++ b/pages/11.troubleshooting/05.invalid-security-token/docs.md
@@ -18,3 +18,5 @@ There are a few possible causes of the problem, all linked to the Session:
 - Check that PHP has the correct tmp path set up. This can be set in PHP directly, or by setting Grav's `system.yaml` `session.path` setting (it can also be set via Admin, in the System Configuration) [Reported issue](https://github.com/getgrav/grav-plugin-admin/issues/958)
 
 - Make sure your web server config is right and includes the query string [Reported issue](https://github.com/getgrav/grav-plugin-admin/issues/893)
+
+- Make sure your hostname doesn't have underscores in it. It will cause the hostname to default to `unknown`, making the session invalid.


### PR DESCRIPTION
Added "Make sure your hostname doesn't have underscores in it. It will cause the hostname to default to `unknown`, making the session invalid."