### PR TITLE
Update docs.md

### DIFF
--- a/pages/01.basics/02.requirements/docs.md
+++ b/pages/01.basics/02.requirements/docs.md
@@ -131,7 +131,7 @@ groups USERNAME
 [prism classes="language-bash line-numbers"]
 chgrp -R GROUP .
 find . -type f | xargs chmod 664
-find ./bin -type f | xargs chmod 775
+find . /bin -type f | xargs chmod 775
 find . -type d | xargs chmod 775
 find . -type d | xargs chmod +s
 umask 0002


### PR DESCRIPTION
ln 134 - added space between '.' and '/bin' to correct the bash command.