### PR TITLE
Update docs.md

### DIFF
--- a/pages/02.content/11.multi-language/docs.md
+++ b/pages/02.content/11.multi-language/docs.md
@@ -322,7 +322,7 @@ $translation = $this->grav['language']->translate(['HEADER.MAIN_TEXT']);
 You can also specify a language:
 
 [prism classes="language-php line-numbers"]
-$translation = $this->grav['language']->translate(['HEADER.MAIN_TEXT'], 'fr');
+$translation = $this->grav['language']->translate(['HEADER.MAIN_TEXT'], ['fr']);
 [/prism]
 
 To translate a specific item in an array use:


### PR DESCRIPTION
According to the API reference the second parameter of the translate function must be an array. Otherwise execution fails with a TypeError.