### PR TITLE
Remove duplicate description of `html_lang` variable

### DIFF
--- a/pages/03.themes/06.theme-vars/docs.md
+++ b/pages/03.themes/06.theme-vars/docs.md
@@ -52,10 +52,6 @@ The `{{ theme_url }}` returns the relative URL to the current theme.
 
 !! When linking to assets like images or JavaScript and CSS files, it's recommended to use the `url()` function in combination with the `theme://` stream as described on the [Twig Filters & Functions](/themes/twig-filters-functions#url) page. For JavaScript and CSS, the [Asset Manager](/themes/asset-manager) is even easier to use but in some cases like dynamic or conditional loading of assets, it will not work.
 
-### html_lang variable
-
-The `{{ html_lang }}` returns the active language.
-
 ### language_codes variable
 
 The `{{ language_codes }}` returns list of available languages of the site.


### PR DESCRIPTION
Removed a duplicated explanation of the `html_lang` variable in the [Theme Variables](https://learn.getgrav.org/17/themes/theme-vars#html-lang-variable) documentation page.
