### PR TITLE
Update docs.md

### DIFF
--- a/pages/03.themes/04.twig-tags-filters-functions/01.tags/docs.md
+++ b/pages/03.themes/04.twig-tags-filters-functions/01.tags/docs.md
@@ -96,7 +96,7 @@ In most programming language, using a `switch` statement is a common way to make
 
 With traditional blocks, once the block has been rendered, it cannot be manipulated.  Take the example of a `{% block scripts %}` that might hold some entries for JavaScript includes.  If you have a child Twig template, and you extend a base template where this block is defined, you can extend the block, and add your own custom JavaScript entries.  However, partial twig templates that are included from this page, cannot reach or interact with the block.
 
-The deferred attribute on the block which is powered by the [Deferred Extension](https://github.com/rybakit/twig-deferred-extension), means that you can define this block in any Twig template, but it's rendering is deferred, so that it renders after everything else.  This means that you can add JavaScript references via the `{% do assets.addJs() %}` call from anywhere in your page, and because the rendering is deferred, the output will contain all the assets that Grav knows about, no matter when you added them.
+The deferred attribute on the block which is powered by the [Deferred Extension](https://github.com/rybakit/twig-deferred-extension), means that you can define this block in any Twig template, but its rendering is deferred, so that it renders after everything else.  This means that you can add JavaScript references via the `{% do assets.addJs() %}` call from anywhere in your page, and because the rendering is deferred, the output will contain all the assets that Grav knows about, no matter when you added them.
 
 [prism classes="language-twig line-numbers"]
 {% block myblock deferred %}


### PR DESCRIPTION
small grammatical mistake:
"it's" was used instead of "its"