### PR TITLE
Markdown alert syntax description

### DIFF
--- a/pages/17/01.basics/04.basic-tutorial/doc.md
+++ b/pages/17/01.basics/04.basic-tutorial/doc.md
@@ -50,8 +50,7 @@ body_classes: title-center title-h1h2
 
 Congratulations! You have installed the **Base Grav Package** that provides a **simple page** and the default **Quark** theme to get you started.
 
-> [!CAUTION]
-> If you see a **404 Error** when you click `Typography` in the menu, please refer to the [troubleshooting guide](https://learn.getgrav.org/troubleshooting/page-not-found).
+!! If you see a **404 Error** when you click `Typography` in the menu, please refer to the [troubleshooting guide](https://learn.getgrav.org/troubleshooting/page-not-found).
 [/codesh]
 [/div]
 
@@ -78,8 +77,7 @@ Congratulations! You have installed the **Base Grav Package** that provides a **
 This is a simple paragraph that would have been wrapped in regular `<p>` tags when converted to HTML.  The `**` markers indicate bold text or `<strong>`, formerly `<b>`, in HTML.  Italic text is indicated by wrapping text in `_` markers.
 
 [codesh=markdown line-numbers="true"]
-> [!CAUTION]
-> If you see a **404 Error** when you click `Typography` in the menu, please refer to the [troubleshooting guide](https://learn.getgrav.org/troubleshooting/page-not-found).
+!! If you see a **404 Error** when you click `Typography` in the menu, please refer to the [troubleshooting guide](https://learn.getgrav.org/troubleshooting/page-not-found).
 [/codesh]
 
 This section uses a custom markdown feature that is provided by the included `markdown-notices` plugin.  This allows you to create simple notices by prefix a paragraph of text with a number of `!` (exclamation mark) symbols, from `!` to `!!!!`.

--- a/pages/20/01.basics/04.basic-tutorial/doc.md
+++ b/pages/20/01.basics/04.basic-tutorial/doc.md
@@ -82,7 +82,7 @@ This is a simple paragraph that would have been wrapped in regular `<p>` tags wh
 > If you see a **404 Error** when you click `Typography` in the menu, please refer to the [troubleshooting guide](https://learn.getgrav.org/troubleshooting/page-not-found).
 [/codesh]
 
-This section uses a custom markdown feature that is provided by the included `markdown-notices` plugin.  This allows you to create simple notices by prefix a paragraph of text with a number of `!` (exclamation mark) symbols, from `!` to `!!!!`.
+This section uses GitHub-flavored alerts provided by the included `github-markdown-alerts` plugin. This allows you to create notices by starting a blockquote with a specific marker: `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]` or `[!CAUTION]`.
 
 This overview should provide you with a few key pointers for writing Markdown, but you should check out our more [detailed explanation](/20/content/markdown) to get a thorough understanding.
 


### PR DESCRIPTION
- **For Grav v1.7:** Reverted syntax to `markdown-notice` style (`!!`) as it remains the default.
- **For Grav v2.0:** Updated descriptions to `github-markdown-alerts` style (`> [!NOTE]`) to align with the new default plugin.